### PR TITLE
Clarify behaviour of retry step in help and fix English on timeout step help

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/RetryStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/RetryStep/help.html
@@ -1,3 +1,4 @@
 <div>
     Retry the block (up to N times) if any exception happens during its body execution.
+    If an exception happens on the final attempt then it will lead to aborting the build (unless it is caught and processed somehow).
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help.html
@@ -1,5 +1,5 @@
 <div>
     Executes the code inside the block with a determined time out limit.
     If the time limit is reached, an exception is thrown, which leads in aborting 
-    the build (unless it is catched and processed somehow).
+    the build (unless it is caught and processed somehow).
 </div>


### PR DESCRIPTION
This answers a question I had in trying to use retry, whether it would actually cause an exception if the block continued to fail.

I looked in the source code and tried this out to confirm that this is what retry does but it would be useful to say it in the help.