### PR TITLE
Workaround for BUG JENKINS-15146; support for empty environment variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvStep.java
@@ -92,7 +92,7 @@ public class EnvStep extends AbstractStepImpl {
             env.overrideAll(overrides);
             // Workaround for https://issues.jenkins-ci.org/browse/JENKINS-15146
             // Empty values should not be deleted from Environment
-            for (Map.Entry<String, String> e : all.entrySet()) {
+            for (Map.Entry<String, String> e : overrides.entrySet()) {
               env.put(e.getKey(), e.getValue());
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvStep.java
@@ -90,6 +90,11 @@ public class EnvStep extends AbstractStepImpl {
         }
         @Override public void expand(EnvVars env) throws IOException, InterruptedException {
             env.overrideAll(overrides);
+            // Workaround for https://issues.jenkins-ci.org/browse/JENKINS-15146
+            // Empty values should not be deleted from Environment
+            for (Map.Entry<String, String> e : all.entrySet()) {
+              env.put(e.getKey(), e.getValue());
+            }
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvStep.java
@@ -93,7 +93,9 @@ public class EnvStep extends AbstractStepImpl {
             // Workaround for https://issues.jenkins-ci.org/browse/JENKINS-15146
             // Empty values should not be deleted from Environment
             for (Map.Entry<String, String> e : overrides.entrySet()) {
-              env.put(e.getKey(), e.getValue());
+                if (e.getValue().length() == 0) {
+                    env.put(e.getKey(), " ");
+                }
             }
         }
     }


### PR DESCRIPTION
```groovy
withEnv(['FOO=']) { }
```
should set the Environment Variable "FOO" to an empty String. But instead of this it completly removes the Environment Variable.