### PR TITLE
Update help.html

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SleepStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SleepStep/help.html
@@ -2,4 +2,6 @@
     Simply pauses the Pipeline build until the given amount of time has expired.
     Equivalent to (on Unix) <code>sh 'sleep …'</code>.
     May be used to pause one branch of <code>parallel</code> while another proceeds.
+    
+    If unit is ommited then default time unit is SECONDS 
 </div>


### PR DESCRIPTION
Not directly clear what is the default time unit. One more problem is that sleep method exists in groovy also, but their time unit is MILLISECONDS and IDE will try to do code completion using that method and will complaint when different arguments are supplied to the pipeline method. A little bit confusing.
