### PR TITLE
[FIXED JENKINS-37397] Allow use of @Symbols from tools as tool types.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
             <version>2.1</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.4-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
             <version>2.10</version>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ToolStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ToolStep.java
@@ -89,7 +89,7 @@ public final class ToolStep extends AbstractStepImpl {
             ListBoxModel r = new ListBoxModel();
             r.add("<any>", "");
             for (ToolDescriptor<?> desc : ToolInstallation.all()) {
-                String idOrSymbol = symbolForDescriptor(desc);
+                String idOrSymbol = SymbolLookup.getSymbolValue(desc);
                 if (idOrSymbol == null) {
                     idOrSymbol = desc.getId();
                 }
@@ -103,7 +103,7 @@ public final class ToolStep extends AbstractStepImpl {
             ListBoxModel r = new ListBoxModel();
 
             for (ToolDescriptor<?> desc : ToolInstallation.all()) {
-                if (type != null && !desc.getId().equals(type) && !type.equals(symbolForDescriptor(desc))) {
+                if (type != null && !desc.getId().equals(type) && !type.equals(SymbolLookup.getSymbolValue(desc))) {
                     continue;
                 }
                 for (ToolInstallation tool : desc.getInstallations()) {
@@ -126,7 +126,7 @@ public final class ToolStep extends AbstractStepImpl {
             String name = step.getName();
             String type = step.getType();
             for (ToolDescriptor<?> desc : ToolInstallation.all()) {
-                if (type != null && !desc.getId().equals(type) && !type.equals(symbolForDescriptor(desc))) {
+                if (type != null && !desc.getId().equals(type) && !type.equals(SymbolLookup.getSymbolValue(desc))) {
                     continue;
                 }
                 for (ToolInstallation tool : desc.getInstallations()) {
@@ -146,25 +146,6 @@ public final class ToolStep extends AbstractStepImpl {
 
         private static final long serialVersionUID = 1L;
 
-    }
-
-    /**
-     * Finds the {@code @Symbol} on the given {@link ToolDescriptor}, if it exists.
-     * TODO: This should probably go somewhere else - maybe {@link SymbolLookup}?
-     *
-     * @param desc A {@link ToolDescriptor}
-     * @return The {@code @Symbol} value for that descriptor, or null if not present.
-     */
-    public static String symbolForDescriptor(ToolDescriptor<?> desc) {
-        Symbol s = desc.getClass().getAnnotation(Symbol.class);
-        if (s != null) {
-            for (String t : s.value()) {
-                if (t != null) {
-                    return t;
-                }
-            }
-        }
-        return null;
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ToolStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ToolStep.java
@@ -142,6 +142,7 @@ public final class ToolStep extends AbstractStepImpl {
                         if (tool instanceof EnvironmentSpecific) {
                             tool = (ToolInstallation) ((EnvironmentSpecific<?>) tool).forEnvironment(env);
                         }
+
                         return tool.getHome();
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ToolStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ToolStep.java
@@ -39,11 +39,12 @@ import hudson.util.ListBoxModel;
 import javax.annotation.CheckForNull;
 import javax.inject.Inject;
 
-import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.SymbolLookup;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+
+import java.util.Set;
 
 /**
  * Binds a {@link ToolInstallation} to a variable.
@@ -89,10 +90,14 @@ public final class ToolStep extends AbstractStepImpl {
             ListBoxModel r = new ListBoxModel();
             r.add("<any>", "");
             for (ToolDescriptor<?> desc : ToolInstallation.all()) {
-                String idOrSymbol = SymbolLookup.getSymbolValue(desc);
-                if (idOrSymbol == null) {
-                    idOrSymbol = desc.getId();
+                String idOrSymbol = desc.getId();
+
+                Set<String> symbols = SymbolLookup.getSymbolValue(desc);
+
+                if (!symbols.isEmpty()) {
+                    idOrSymbol = symbols.iterator().next();
                 }
+
                 r.add(desc.getDisplayName(), idOrSymbol);
             }
             return r;
@@ -103,7 +108,7 @@ public final class ToolStep extends AbstractStepImpl {
             ListBoxModel r = new ListBoxModel();
 
             for (ToolDescriptor<?> desc : ToolInstallation.all()) {
-                if (type != null && !desc.getId().equals(type) && !type.equals(SymbolLookup.getSymbolValue(desc))) {
+                if (type != null && !desc.getId().equals(type) && !SymbolLookup.getSymbolValue(desc).contains(type)) {
                     continue;
                 }
                 for (ToolInstallation tool : desc.getInstallations()) {
@@ -126,7 +131,7 @@ public final class ToolStep extends AbstractStepImpl {
             String name = step.getName();
             String type = step.getType();
             for (ToolDescriptor<?> desc : ToolInstallation.all()) {
-                if (type != null && !desc.getId().equals(type) && !type.equals(SymbolLookup.getSymbolValue(desc))) {
+                if (type != null && !desc.getId().equals(type) && !SymbolLookup.getSymbolValue(desc).contains(type)) {
                     continue;
                 }
                 for (ToolInstallation tool : desc.getInstallations()) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/ToolStepRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/ToolStepRunTest.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.workflow.steps;
 
 import hudson.tasks.Maven;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.structs.SymbolLookup;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.ClassRule;
@@ -45,7 +46,7 @@ public class ToolStepRunTest {
         String name = tool.getName();
         Maven.MavenInstallation.DescriptorImpl desc = Jenkins.getInstance().getDescriptorByType(Maven.MavenInstallation.DescriptorImpl.class);
 
-        String type = ToolStep.symbolForDescriptor(desc);
+        String type = SymbolLookup.getSymbolValue(desc);
 
         // Defensive - Maven doesn't have a symbol before 2.x, and other tools may still not have symbols after that.
         if (type == null) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/ToolStepRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/ToolStepRunTest.java
@@ -36,6 +36,8 @@ import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.ToolInstallations;
 
+import java.util.Set;
+
 public class ToolStepRunTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
@@ -46,11 +48,13 @@ public class ToolStepRunTest {
         String name = tool.getName();
         Maven.MavenInstallation.DescriptorImpl desc = Jenkins.getInstance().getDescriptorByType(Maven.MavenInstallation.DescriptorImpl.class);
 
-        String type = SymbolLookup.getSymbolValue(desc);
-
         // Defensive - Maven doesn't have a symbol before 2.x, and other tools may still not have symbols after that.
-        if (type == null) {
-            type = desc.getId();
+        String type = desc.getId();
+
+        Set<String> symbols = SymbolLookup.getSymbolValue(desc);
+
+        if (!symbols.isEmpty()) {
+            type = symbols.iterator().next();
         }
 
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/ToolStepRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/ToolStepRunTest.java
@@ -24,8 +24,13 @@
 
 package org.jenkinsci.plugins.workflow.steps;
 
+import hudson.model.Result;
 import hudson.tasks.Maven;
+import hudson.tools.ToolDescriptor;
+import hudson.tools.ToolInstallation;
+import hudson.tools.ToolProperty;
 import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.SymbolLookup;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -34,8 +39,12 @@ import org.junit.Test;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.ToolInstallations;
 
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.util.List;
 import java.util.Set;
 
 public class ToolStepRunTest {
@@ -64,4 +73,69 @@ public class ToolStepRunTest {
         r.assertLogContains("Apache Maven 3", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }
 
+    @Test public void toolWithSymbol() throws Exception {
+        File buildDirectory = new File(System.getProperty("buildDirectory", "target")); // TODO relative path
+        File toolHome = new File(buildDirectory, "mockTools");
+        MockToolWithSymbol tool = new MockToolWithSymbol("mock-tool-with-symbol", toolHome.getAbsolutePath(), JenkinsRule.NO_PROPERTIES);
+        Jenkins.getInstance().getDescriptorByType(MockToolWithSymbol.MockToolWithSymbolDescriptor.class).setInstallations(tool);
+        String name = tool.getName();
+
+        String type = "mockToolWithSymbol";
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {def home = tool name: '" + name + "', type: '" + type + "'}",
+                true));
+
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test public void toolWithoutSymbol() throws Exception {
+        File buildDirectory = new File(System.getProperty("buildDirectory", "target")); // TODO relative path
+        File toolHome = new File(buildDirectory, "mockTools");
+        MockToolWithoutSymbol tool = new MockToolWithoutSymbol("mock-tool-without-symbol", toolHome.getAbsolutePath(), JenkinsRule.NO_PROPERTIES);
+        Jenkins.getInstance().getDescriptorByType(MockToolWithoutSymbol.MockToolWithoutSymbolDescriptor.class).setInstallations(tool);
+        String name = tool.getName();
+
+        String type = "mockToolWithoutSymbol";
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {def home = tool name: '" + name + "', type: '" + type + "'}",
+                true));
+
+        r.assertLogContains("No mockToolWithoutSymbol named mock-tool-without-symbol found",
+                r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(p.scheduleBuild2(0).waitForStart())));
+    }
+
+    public static class MockToolWithSymbol extends ToolInstallation {
+        public MockToolWithSymbol(String name, String home, List<? extends ToolProperty<?>> properties) {
+            super(name, home, properties);
+        }
+
+        @TestExtension
+        @Symbol("mockToolWithSymbol")
+        public static class MockToolWithSymbolDescriptor extends ToolDescriptor<MockToolWithSymbol> {
+            @Override
+            @Nonnull
+            public String getDisplayName() {
+                return "MockToolWithSymbol";
+            }
+
+        }
+    }
+
+    public static class MockToolWithoutSymbol extends ToolInstallation {
+        public MockToolWithoutSymbol(String name, String home, List<? extends ToolProperty<?>> properties) {
+            super(name, home, properties);
+        }
+
+        @TestExtension
+        public static class MockToolWithoutSymbolDescriptor extends ToolDescriptor<MockToolWithoutSymbol> {
+            @Override
+            @Nonnull
+            public String getDisplayName() {
+                return "MockToolWithoutSymbol";
+            }
+
+        }
+    }
 }


### PR DESCRIPTION
[JENKINS-37397](https://issues.jenkins-ci.org/browse/JENKINS-37397)

Fall back to allowing descriptor IDs as well.

[JENKINS-37386](https://issues.jenkins-ci.org/browse/JENKINS-37386) is driving getting `@Symbol` on `ToolDescriptor`s, so this will not be hugely useful until that's everywhere, but still, better to do ahead of time than after the fact!

cc @reviewbybees esp @jglick and @oleg-nenashev 