### PR TITLE
[JENKINS-31931] Adding test case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.5</version>
-        <relativePath />
+        <version>2.14</version>
+        <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-basic-steps</artifactId>
@@ -52,13 +52,13 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
     <properties>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ArtifactArchiverStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ArtifactArchiverStepExecution.java
@@ -39,6 +39,7 @@ public class ArtifactArchiverStepExecution extends AbstractSynchronousNonBlockin
 
     @Override
     protected Void run() throws Exception {
+        ws.mkdirs();
         Map<String,String> files = ws.act(new ListFiles(step.getIncludes(), step.getExcludes()));
         build.pickArtifactManager().archive(ws, launcher, new BuildListenerAdapter(listener), files);
         return null;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
@@ -65,6 +65,7 @@ public final class CoreStep extends AbstractStepImpl {
         @StepContextParameter private transient TaskListener listener;
 
         @Override protected Void run() throws Exception {
+            workspace.mkdirs();
             step.delegate.perform(run, workspace, launcher, listener);
             return null;
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/ArtifactArchiverStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/ArtifactArchiverStepTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow.steps;
 
+import java.util.Arrays;
 import jenkins.util.VirtualFile;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -9,9 +10,8 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.util.Arrays;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -41,6 +41,13 @@ public class ArtifactArchiverStepTest extends Assert {
         VirtualFile archivedFile = b.getArtifactManager().root().child("msg.out");
         assertTrue(archivedFile.exists());
         assertEquals("hello world", IOUtils.toString(archivedFile.open()));
+    }
+
+    @Issue("JENKINS-31931")
+    @Test public void nonexistent() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {archive 'nonexistent/'}", true));
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
     @Test public void unarchiveDir() throws Exception {


### PR DESCRIPTION
[JENKINS-31931](https://issues.jenkins-ci.org/browse/JENKINS-31931)

Also fixing a buglet that archiving from a nonexistent workspace should not automatically fail, except insofar as archiving no files would. Cf. [JENKINS-28121](https://issues.jenkins-ci.org/browse/JENKINS-28121) which also deals with nonexistent workspaces. Generally it is up to each step which expects a context directory to exist to actually make that directory; otherwise `dir('mayOrMayNotExist') {fileExists 'something'}` would gratuitously `mkdirs`, for example.

@reviewbybees