### PR TITLE
[JENKINS-26521] Add activity feature to timeout step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.5</version>
+        <version>2.14</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStep.java
@@ -19,6 +19,8 @@ public class TimeoutStep extends AbstractStepImpl implements Serializable {
 
     private TimeUnit unit = TimeUnit.MINUTES;
 
+    private boolean activity = false;
+
     @DataBoundConstructor
     public TimeoutStep(int time) {
         this.time = time;
@@ -35,6 +37,23 @@ public class TimeoutStep extends AbstractStepImpl implements Serializable {
 
     public TimeUnit getUnit() {
         return unit;
+    }
+
+    /**
+     * @param activity to watch timeout of activity
+     * @since 2.2
+     */
+    @DataBoundSetter
+    public void setActivity(boolean activity) {
+        this.activity = activity;
+    }
+
+    /**
+     * @return to watch timeout of activity
+     * @since 2.2
+     */
+    public boolean isActivity() {
+        return activity;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
@@ -2,6 +2,13 @@ package org.jenkinsci.plugins.workflow.steps;
 
 import com.google.inject.Inject;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.console.ConsoleLogFilter;
+import hudson.console.LineTransformationOutputStream;
+import hudson.model.Run;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -18,32 +25,52 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
     private BodyExecution body;
     private transient ScheduledFuture<?> killer;
 
+    private long timeout = 0;
     private long end = 0;
 
     @Override
     public boolean start() throws Exception {
         StepContext context = getContext();
-        body = context.newBodyInvoker()
-                .withCallback(new Callback())
-                .start();
-        long now = System.currentTimeMillis();
-        end = now + step.getUnit().toMillis(step.getTime());
-        setupTimer(now);
+        BodyInvoker bodyInvoker = context.newBodyInvoker()
+                .withCallback(new Callback());
+
+        if (step.isActivity()) {
+            bodyInvoker = bodyInvoker.withContext(
+                BodyInvoker.mergeConsoleLogFilters(
+                    context.get(ConsoleLogFilter.class),
+                    new ConsoleLogFilterImpl(new ResetCallback())
+                )
+            );
+        }
+
+        body = bodyInvoker.start();
+        timeout = step.getUnit().toMillis(step.getTime());
+        resetTimer();
         return false;   // execution is asynchronous
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        setupTimer(System.currentTimeMillis());
+        setupTimer(System.currentTimeMillis(), false);
     }
 
     /**
      * Sets the timer to manage the timeout.
      *
      * @param now Current time in milliseconds.
+     * @param force reset timer if already set
      */
-    private void setupTimer(final long now) {
+    private void setupTimer(final long now, boolean force) {
+        if (killer != null) {
+            if (!force) {
+                // already set
+                return;
+            }
+            killer.cancel(true);
+            killer = null;
+        }
+
         if (end > now) {
             killer = Timer.get().schedule(new Runnable() {
                 @Override
@@ -54,6 +81,12 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
         } else {
             body.cancel(new ExceededTimeout());
         }
+    }
+
+    private void resetTimer() {
+        long now = System.currentTimeMillis();
+        end = now + timeout;
+        setupTimer(now, true);
     }
 
     @Override
@@ -75,6 +108,14 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
 
     }
 
+    private class ResetCallback implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private void logWritten() {
+            resetTimer();
+        }
+    }
+
     /**
      * Common cause in this step.
      */
@@ -85,6 +126,41 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
         @Override
         public String getShortDescription() {
             return "Timeout has been exceeded";
+        }
+    }
+
+    private static class ConsoleLogFilterImpl extends ConsoleLogFilter implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final ResetCallback callback;
+
+        public ConsoleLogFilterImpl(ResetCallback callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public OutputStream decorateLogger(@SuppressWarnings("rawtypes") Run build, final OutputStream logger)
+            throws IOException, InterruptedException
+        {
+            return new LineTransformationOutputStream() {
+                @Override
+                protected void eol(byte[] b, int len) throws IOException {
+                    logger.write(b, 0, len);
+                    callback.logWritten();
+                }
+
+                @Override
+                public void flush() throws IOException {
+                    super.flush();
+                    logger.flush();
+                }
+
+                @Override
+                public void close() throws IOException {
+                    super.close();
+                    logger.close();
+                }
+            };
         }
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/config.jelly
@@ -31,4 +31,7 @@ THE SOFTWARE.
     <f:entry field="unit" title="Unit">
         <f:select/>
     </f:entry>
+    <f:entry field="activity" title="Timeout of activity">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help-activity.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help-activity.html
@@ -1,0 +1,4 @@
+<div>
+Watch timeouts from last log outputs.
+This is useful to make codes timeout when no logs are output for a long time and they are suspected to be stacked.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepRunTest.java
@@ -151,6 +151,72 @@ public class TimeoutStepRunTest extends Assert {
         });
     }
 
+    @Test
+    public void activity() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  timeout(time:5, unit:'SECONDS', activity: true) {\n"
+                        + "    echo 'NotHere';\n"
+                        + "    sleep 3;\n"
+                        + "    echo 'NotHereYet';\n"
+                        + "    sleep 3;\n"
+                        + "    echo 'JustHere!';\n"
+                        + "    sleep 10;\n"
+                        + "    echo 'ShouldNot!';\n"
+                        + "  }\n"
+                        + "}\n"
+                ));
+                WorkflowRun b = story.j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0).get());
+                story.j.assertLogContains("JustHere!", b);
+                story.j.assertLogNotContains("ShouldNot!", b);
+            }
+        });
+    }
+
+
+    @Test
+    public void activity_restart() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "restarted");
+                p.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  timeout(time:15, unit:'SECONDS', activity: true) {\n"
+                        + "    echo 'NotHere';\n"
+                        + "    semaphore 'restarted'\n"
+                        + "    echo 'NotHereYet';\n"
+                        + "    sleep 10;\n"
+                        + "    echo 'NotHereYet';\n"
+                        + "    sleep 10;\n"
+                        + "    echo 'JustHere!';\n"
+                        + "    sleep 30;\n"
+                        + "    echo 'ShouldNot!';\n"
+                        + "  }\n"
+                        + "}\n"
+                ));
+                WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();
+                SemaphoreStep.waitForStart("restarted/1", b);
+            }
+        });
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.getItemByFullName("restarted", WorkflowJob.class);
+                WorkflowRun b = p.getBuildByNumber(1);
+                assertTrue("took more than 15s to restart?", b.isBuilding());
+                SemaphoreStep.success("restarted/1", null);
+                story.j.assertBuildStatus(Result.ABORTED, story.j.waitForCompletion(b));
+                story.j.assertLogContains("JustHere!", b);
+                story.j.assertLogNotContains("ShouldNot!", b);
+            }
+        });
+    }
+
     // TODO: timeout inside parallel
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
@@ -38,9 +38,16 @@ public class TimeoutStepTest {
         TimeoutStep s1 = new TimeoutStep(3);
         s1.setUnit(TimeUnit.HOURS);
         TimeoutStep s2 = new StepConfigTester(r).configRoundTrip(s1);
-        // assertEqualDataBoundBeans does not currently work on @DataBoundSetter:
-        assertEquals(3, s2.getTime());
-        assertEquals(TimeUnit.HOURS, s2.getUnit());
+        r.assertEqualDataBoundBeans(s1, s2);
+    }
+
+    @Test public void configRoundTripWithActivity() throws Exception {
+        TimeoutStep s1 = new TimeoutStep(3);
+        s1.setUnit(TimeUnit.HOURS);
+        assertFalse(s1.isActivity());
+        s1.setActivity(true);
+        TimeoutStep s2 = new StepConfigTester(r).configRoundTrip(s1);
+        r.assertEqualDataBoundBeans(s1, s2);
     }
 
 }


### PR DESCRIPTION
[JENKINS-26521](https://issues.jenkins-ci.org/browse/JENKINS-26521)
{quote}
Some of our test-suite items can occasionally deadlock, causing a build to never finish. The Build Timeout Plugin supports failing a job when nothing happens (i.e. no log output) for a sufficient length of time. It would be good to get this behaviour in Workflow.
{quote}

This change adds "activity" option, which makes timeout steps to watch not timeout from starts of blocks, but from last log outputs.
This works just like [`NoActivityTimeOutStrategy` of Build-Timeout plugin](https://github.com/jenkinsci/build-timeout-plugin/blob/master/src/main/java/hudson/plugins/build_timeout/impl/NoActivityTimeOutStrategy.java)
