### PR TITLE
[JENKINS-27396] Introduce elastic and id to timeout step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.5</version>
+        <version>2.14</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/actions/TimeoutInfoAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/actions/TimeoutInfoAction.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.actions;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.workflow.steps.TimeoutStep;
+
+import hudson.model.Action;
+
+/**
+ * Information to calculate timeouts for {@link TimeoutStep}
+ *
+ * @since 2.2
+ */
+public class TimeoutInfoAction implements Action {
+    private final String id;
+    private final long duration;
+
+    public TimeoutInfoAction(@Nonnull String id, long duration) {
+        this.id = id;
+        this.duration = duration;
+    }
+
+    /**
+     * @return id of this timeout block
+     */
+    @Nonnull
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @return execution duration of this block
+     */
+    public long getDuration() {
+        return duration;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDisplayName() {
+        return "TimeoutInfo";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStep.java
@@ -1,12 +1,15 @@
 package org.jenkinsci.plugins.workflow.steps;
 
 import hudson.Extension;
+import hudson.Util;
 import hudson.util.ListBoxModel;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
+
+import javax.annotation.CheckForNull;
 
 /**
  * Executes the body with a timeout, which will kill the body.
@@ -18,6 +21,10 @@ public class TimeoutStep extends AbstractStepImpl implements Serializable {
     private final int time;
 
     private TimeUnit unit = TimeUnit.MINUTES;
+
+    private String id;
+
+    private float elastic;
 
     @DataBoundConstructor
     public TimeoutStep(int time) {
@@ -35,6 +42,43 @@ public class TimeoutStep extends AbstractStepImpl implements Serializable {
 
     public TimeUnit getUnit() {
         return unit;
+    }
+
+    /**
+     * @param id name for this block
+     * @since 2.2
+     */
+    @DataBoundSetter
+    public void setId(@CheckForNull String id) {
+        this.id = Util.fixEmptyAndTrim(id);
+    }
+
+    /**
+     * @return name for this block
+     * @since 2.2
+     */
+    @CheckForNull
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @param elastic percentage to decide timeout limit from last builds.
+     *     0 or negative values to disable.
+     * @since 2.2
+     */
+    @DataBoundSetter
+    public void setElastic(float elastic) {
+        this.elastic = elastic;
+    }
+
+    /**
+     * @return percentage to decide timeout limit from last builds.
+     *     0 or negative values to disable
+     * @since 2.2
+     */
+    public float getElastic() {
+        return elastic;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
@@ -2,8 +2,22 @@ package org.jenkinsci.plugins.workflow.steps;
 
 import com.google.inject.Inject;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+import java.io.IOException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+
+import javax.annotation.CheckForNull;
+
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.actions.TimeoutInfoAction;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 import jenkins.model.CauseOfInterruption;
 import jenkins.util.Timer;
@@ -13,21 +27,42 @@ import jenkins.util.Timer;
  */
 @SuppressFBWarnings("SE_INNER_CLASS")
 public class TimeoutStepExecution extends AbstractStepExecutionImpl {
+    public static final String VARNAME = "timeout";
+
     @Inject(optional=true)
     private transient TimeoutStep step;
     private BodyExecution body;
     private transient ScheduledFuture<?> killer;
 
+    private String id = null;
+    private long start = 0;
+    private long timeout;
     private long end = 0;
+
+    @StepContextParameter
+    private transient TaskListener listener;
 
     @Override
     public boolean start() throws Exception {
+        id = step.getId();
+        timeout = calculateTimeout();
+        listener.getLogger().println(String.format(
+            "Use %d msec for timeout value",
+            timeout
+        ));
+
         StepContext context = getContext();
         body = context.newBodyInvoker()
                 .withCallback(new Callback())
+                .withContext(EnvironmentExpander.merge(
+                    context.get(EnvironmentExpander.class),
+                    new EnvironmentExpanderImpl(timeout)
+                ))
                 .start();
-        long now = System.currentTimeMillis();
-        end = now + step.getUnit().toMillis(step.getTime());
+        start = System.currentTimeMillis();
+        long now = start;
+        end = now + timeout;
+        listener.getLogger().println();
         setupTimer(now);
         return false;   // execution is asynchronous
     }
@@ -36,6 +71,83 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
     public void onResume() {
         super.onResume();
         setupTimer(System.currentTimeMillis());
+    }
+
+    private long calculateTimeout() {
+        long baseTimeout = step.getUnit().toMillis(step.getTime());
+        if (step.getElastic() > 0) {
+            try {
+                long elasticTimeout = calculateElasticTimeout();
+                if (elasticTimeout > 0) {
+                    return elasticTimeout;
+                }
+            } catch (Exception e) {
+                listener.error("Failed to calculate the elastic timeout limit:");
+                e.printStackTrace(listener.getLogger());
+            }
+        }
+        return baseTimeout;
+    }
+
+    private long calculateElasticTimeout() throws Exception {
+        if (StringUtils.isBlank(id)) {
+            listener.error(
+                "No id is set for timeout block. Cannot calculate elastic timeout limit."
+            );
+            return 0;
+        }
+        Run<?, ?> run = getContext().get(Run.class);
+        Run<?, ?> previous = run.getPreviousSuccessfulBuild();
+        if (previous == null) {
+            listener.getLogger().println(
+                "No previous successful build to calculate elastic timeout limit."
+            );
+            return 0;
+        }
+        TimeoutInfoAction info = extractTimeoutInfoActionWithId(id, previous);
+        if (info == null) {
+            listener.getLogger().println(
+                "No duration time is recorded in the last successful build"
+                + " to calculate elastic timeout limit."
+            );
+            return 0;
+        }
+        long duration = (long)(step.getElastic() * info.getDuration());
+        if (duration <= 0) {
+            listener.getLogger().println(
+                "Calcuated elastic timeout limit gets 0. Ignored."
+            );
+            return 0;
+        }
+        return duration;
+    }
+
+    /**
+     * Extract the first {@link TimeoutInfoAction} from a run
+     *
+     * Put in the package scope for testing purpose.
+     *
+     * @param id id for {@link TimeoutInfoAction}
+     * @param run run to extract {@link TimeoutInfoAction} from
+     * @return an instance of {@link TimeoutInfoAction} if found, {@code null} if not found
+     * @throws IOException 
+     */
+    @CheckForNull
+    /*package*/ static TimeoutInfoAction extractTimeoutInfoActionWithId(String id, Run<?, ?> run) throws IOException {
+        if (!(run instanceof FlowExecutionOwner.Executable)) {
+            return null;
+        }
+        FlowExecution execution = ((FlowExecutionOwner.Executable)run).asFlowExecutionOwner().get();
+        for (FlowNode node: new FlowGraphWalker(execution)) {
+            TimeoutInfoAction action = node.getAction(TimeoutInfoAction.class);
+            if (action == null) {
+                continue;
+            }
+            if (action.getId().equals(id)) {
+                return action;
+            }
+        }
+        return null;
     }
 
     /**
@@ -62,13 +174,34 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
             body.cancel(cause);
     }
 
+    private void finished() throws Exception {
+        if (killer!=null) {
+            killer.cancel(true);
+            killer = null;
+        }
+        long duration = System.currentTimeMillis() - start;
+        listener.getLogger().println(String.format(
+            "End of timeout block. Elapsed %s msec",
+            duration
+        ));
+        if (!StringUtils.isBlank(id)) {
+            // Record execution duration of body
+            // * Record even if the build is aborted for timeout
+            //     * We use durations only of successful runs
+            // * Don't care the down time: there's no way to get that.
+            getContext().get(FlowNode.class).addAction(
+                new TimeoutInfoAction(
+                    id,
+                    duration
+                )
+            );
+        }
+    }
+
     private class Callback extends BodyExecutionCallback.TailCall {
 
         @Override protected void finished(StepContext context) throws Exception {
-            if (killer!=null) {
-                killer.cancel(true);
-                killer = null;
-            }
+            TimeoutStepExecution.this.finished();
         }
 
         private static final long serialVersionUID = 1L;
@@ -88,5 +221,21 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
         }
     }
 
+    private static final class EnvironmentExpanderImpl extends EnvironmentExpander {
+        private static final long serialVersionUID = 1L;
+
+        private final long timeout;
+
+        public EnvironmentExpanderImpl(long timeout) {
+            this.timeout = timeout;
+        }
+
+        @Override
+        public void expand(EnvVars env) throws IOException, InterruptedException {
+            env.put(VARNAME, Long.toString(timeout));
+        }
+        
+    }
+ 
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.actions.TimeoutInfoAction;
@@ -133,11 +134,15 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
      * @throws IOException 
      */
     @CheckForNull
-    /*package*/ static TimeoutInfoAction extractTimeoutInfoActionWithId(String id, Run<?, ?> run) throws IOException {
+    /*package*/ static TimeoutInfoAction extractTimeoutInfoActionWithId(@Nonnull String id, @Nonnull Run<?, ?> run) throws IOException {
         if (!(run instanceof FlowExecutionOwner.Executable)) {
             return null;
         }
-        FlowExecution execution = ((FlowExecutionOwner.Executable)run).asFlowExecutionOwner().get();
+        FlowExecutionOwner owner = ((FlowExecutionOwner.Executable)run).asFlowExecutionOwner();
+        if (owner == null) {
+            return null;
+        }
+        FlowExecution execution = owner.get();
         for (FlowNode node: new FlowGraphWalker(execution)) {
             TimeoutInfoAction action = node.getAction(TimeoutInfoAction.class);
             if (action == null) {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/config.jelly
@@ -31,4 +31,10 @@ THE SOFTWARE.
     <f:entry field="unit" title="Unit">
         <f:select/>
     </f:entry>
+    <f:entry field="id" title="ID">
+        <f:textbox />
+    </f:entry>
+    <f:entry field="elastic" title="Rate for elastic timeout">
+        <f:textbox />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help-elastic.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help-elastic.html
@@ -1,0 +1,12 @@
+<div>
+<p>
+Decide timeout limit from the duration of the timeout block in the last successful build.
+Requires <code>ID</code>.
+Timeout is used for the default value when elastic timeout limit cannot be calculated
+(e.g., there's no previous successful builds).
+</p>
+<p>
+Specify the rate for timeout limit to the last duration.
+E.g. specifying 2.0 makes timeout limit twice of the last duration.
+</p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help-id.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help-id.html
@@ -1,0 +1,4 @@
+<div>
+Used to identify this timeout block.
+This is used for e.g. calculating timeout limits from duration of previous executions.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
@@ -38,9 +38,18 @@ public class TimeoutStepTest {
         TimeoutStep s1 = new TimeoutStep(3);
         s1.setUnit(TimeUnit.HOURS);
         TimeoutStep s2 = new StepConfigTester(r).configRoundTrip(s1);
-        // assertEqualDataBoundBeans does not currently work on @DataBoundSetter:
-        assertEquals(3, s2.getTime());
-        assertEquals(TimeUnit.HOURS, s2.getUnit());
+        r.assertEqualDataBoundBeans(s1, s2);
     }
 
+    @Test public void configRoundTripForElastic() throws Exception {
+        TimeoutStep s1 = new TimeoutStep(3);
+        s1.setUnit(TimeUnit.HOURS);
+        assertNull(s1.getId());
+        // delta=0.0f as 0.0f can be exactly expressed.
+        assertEquals(0.0f, s1.getElastic(), 0.0f);
+        s1.setId("main");
+        s1.setElastic(1.5f);
+        TimeoutStep s2 = new StepConfigTester(r).configRoundTrip(s1);
+        r.assertEqualDataBoundBeans(s1, s2);
+    }
 }


### PR DESCRIPTION
[JENKINS-27396](https://issues.jenkins-ci.org/browse/JENKINS-27396)
`elastic` decides timeout limit from the last execution duration of the block in the last successful build.
`id` is the identifier of the block to get the last execution duration.

For example:

```
node {
    timeout(id: 'main', time: 5, unit: 'MINUTES', elastic: 1.5) {
        sh './build.sh`
    }
}
```

means
- This block is identified as "main"
- Timeout when 150% of the last duration is passed.
- Use 5 minutes as the timeout limit if there's no previous builds.

This may require additional changes for these issues. I'd like to hear your opinions:
- `ElasticTimeOutStrategy` in build-timeout plugin provides more features:
  - Features
    - Use mean of several builds to calcurate timeout limit. The number can be specified.
    - Use the default value if the calcurated value is too small.
    - Specify threshold of build results to use.
  - Supporting these features might result `timeout` step have many parameters and have a complicated implementaion.
  - It might be better a) extract "timeout calcurtor" and make it an extension point. b) extract `timeout` step another plugin. (like email-ext-plugin replaces mailer-plugin)
- `timeout` step get noisy with this change.
  - It logs timeout limit when starting.
  - It logs duration when finishing.
