### PR TITLE
Introduce a requireSteps step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/RequireStepsStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/RequireStepsStep.java
@@ -1,0 +1,149 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Baptiste Mathus.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import com.google.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.structs.SymbolLookup;
+import org.jvnet.hudson.annotation_indexer.Index;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Simple step to fail fast if some step is not found.
+ * <p>
+ * <p><strong>WARNING: Global variables not supported yet</strong>.</p>
+ */
+public class RequireStepsStep extends Step {
+
+    @VisibleForTesting
+    static final String ERROR_LOG = "The following steps were not found (warning: global variables checking not supported): %s" +
+            ". Neither among the functions: %s" +
+            ", nor among the symbols: %s";
+
+    private final List<String> steps;
+
+    @DataBoundConstructor
+    public RequireStepsStep(List<String> steps) {
+        this.steps = steps;
+    }
+
+    public List<String> getSteps() {
+        return steps;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new Execution(steps, context);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "requireSteps";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Fail if one the specified steps in the list is not installed.";
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.singleton(TaskListener.class);
+        }
+    }
+
+    public static class Execution extends SynchronousStepExecution<Void> {
+
+        private static final long serialVersionUID = 1L;
+
+        @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Only used when starting.")
+        private transient final List<String> steps;
+
+        Execution(List<String> steps, StepContext context) {
+            super(context);
+            this.steps = steps;
+        }
+
+        @Override
+        protected Void run() throws Exception {
+
+            // Essentially copied from workflow-cps-plugin's DSL.java https://git.io/vMwii
+            Set<String> functions = getFunctions();
+            Set<String> symbols = getSymbols();
+
+            // FIXME : how to get GlobalVariables?
+            // Set<String> globals = TODO
+
+            List<String> notFound = new ArrayList<>();
+            for (String step : steps) {
+                if (!functions.contains(step) && !symbols.contains(step)) {
+                    notFound.add(step);
+                }
+            }
+
+            if (!notFound.isEmpty()) {
+                throw new AbortException(String.format(
+                        ERROR_LOG,
+                        notFound, functions, symbols));
+            }
+
+            return null;
+        }
+
+        private Set<String> getSymbols() throws java.io.IOException {
+            Set<String> symbols = new TreeSet<>();
+            for (Class<?> e : Index.list(Symbol.class, Jenkins.getActiveInstance().pluginManager.uberClassLoader,
+                                         Class.class)) {
+                if (Descriptor.class.isAssignableFrom(e)) {
+                    symbols.addAll(SymbolLookup.getSymbolValue(e));
+                }
+            }
+            return symbols;
+        }
+
+        private TreeSet<String> getFunctions() {
+            TreeSet<String> functions = new TreeSet<>();
+            for (StepDescriptor d : StepDescriptor.all()) {
+                functions.add(d.getFunctionName());
+            }
+            return functions;
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/RequireStepsStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/RequireStepsStep/config.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2017 Baptiste Mathus.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="steps" title="List of required steps">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/RequireStepsStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/RequireStepsStepTest.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Baptiste Mathus.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RequireStepsStepTest {
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void allPluginsPresent() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("requireSteps steps:['pwd','dir'] ", true));
+        WorkflowRun b = r.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void meh() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("requireSteps steps:['pwd','diro']", true));
+        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+
+        boolean errorFoundInLogs = false;
+        for (String line : b.getLog(10)) {
+            if (line.startsWith("ERROR: " + RequireStepsStep.ERROR_LOG.split("%s")[0])) {
+                errorFoundInLogs = true;
+                final String firstPartOfExceptionMessage = line.split("among")[0];
+                assertTrue(firstPartOfExceptionMessage.contains("diro"));
+                assertFalse(firstPartOfExceptionMessage.contains("pwd"));
+            }
+        }
+        assertTrue(errorFoundInLogs);
+    }
+}


### PR DESCRIPTION
Some followup of https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/31 which made me think it would be nice to be more specific. Also, it's sometimes a headache for users to be sure where steps should be coming from.

Sample usage:

```groovy
requireSteps steps:['pwd','findFiles']
```

NOTE: this checks only on functions and symbols, not on global variables. @jglick I am not sure how to do that, apart from adding a dependency against groovy-cps which I suspect is probably not the way to go right?