### PR TITLE
[JENKINS-41276] Do not retry after user abort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 work
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.9-20170206.170109-1</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/20 -->
+            <version>2.9</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.9-20170206.170109-1</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/20 -->
+            <version>2.9</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.10-20170206.175639-3</version> <!-- TODO https://github.com/jenkinsci/workflow-job-plugin/pull/36 -->
+            <version>2.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.19</version>
+        <version>2.21</version>
         <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -85,12 +85,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.4</version>
+            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.4</version>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.10-20170206.170442-2</version> <!-- TODO https://github.com/jenkinsci/workflow-job-plugin/pull/36 -->
+            <version>2.10-20170206.175639-3</version> <!-- TODO https://github.com/jenkinsci/workflow-job-plugin/pull/36 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.7</version>
+            <version>2.9-20170206.170109-1</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/20 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.3</version>
+            <version>2.9-20170206.170109-1</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/20 -->
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.3</version>
+            <version>2.10-20170206.170442-2</version> <!-- TODO https://github.com/jenkinsci/workflow-job-plugin/pull/36 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
@@ -66,13 +66,10 @@ public class RetryStepExecution extends AbstractStepExecutionImpl {
             try {
                 Run run = context.get(Run.class);
                 if (run != null && t instanceof FlowInterruptedException) {
-                    InterruptedBuildAction action = run.getAction(InterruptedBuildAction.class);
-                    if (action != null) {
-                        for (CauseOfInterruption cause : action.getCauses()) {
-                            if (cause instanceof CauseOfInterruption.UserInterruption) {
-                                context.onFailure(t);
-                                return;
-                            }
+                    for (CauseOfInterruption cause : ((FlowInterruptedException) t).getCauses()) {
+                        if (cause instanceof CauseOfInterruption.UserInterruption) {
+                            context.onFailure(t);
+                            return;
                         }
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
@@ -67,13 +67,11 @@ public class RetryStepExecution extends AbstractStepExecutionImpl {
             try {
                 Run run = context.get(Run.class);
                 if (run != null && t instanceof FlowInterruptedException) {
-                    InterruptedBuildAction action = run.getAction(InterruptedBuildAction.class);
-                    if (action != null) {
-                        for (CauseOfInterruption cause : action.getCauses()) {
-                            if (cause instanceof CauseOfInterruption.UserInterruption) {
-                                context.onFailure(t);
-                                return;
-                            }
+                    FlowInterruptedException fie = (FlowInterruptedException) t;
+                    for (CauseOfInterruption cause : fie.getCauses()) {
+                        if (cause instanceof CauseOfInterruption.UserInterruption) {
+                            context.onFailure(t);
+                            return;
                         }
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.workflow.steps;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
-import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.model.CauseOfInterruption;
@@ -67,11 +66,13 @@ public class RetryStepExecution extends AbstractStepExecutionImpl {
             try {
                 Run run = context.get(Run.class);
                 if (run != null && t instanceof FlowInterruptedException) {
-                    FlowInterruptedException fie = (FlowInterruptedException) t;
-                    for (CauseOfInterruption cause : fie.getCauses()) {
-                        if (cause instanceof CauseOfInterruption.UserInterruption) {
-                            context.onFailure(t);
-                            return;
+                    InterruptedBuildAction action = run.getAction(InterruptedBuildAction.class);
+                    if (action != null) {
+                        for (CauseOfInterruption cause : action.getCauses()) {
+                            if (cause instanceof CauseOfInterruption.UserInterruption) {
+                                context.onFailure(t);
+                                return;
+                            }
                         }
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
@@ -2,10 +2,8 @@ package org.jenkinsci.plugins.workflow.steps;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
-import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.model.CauseOfInterruption;
-import jenkins.model.InterruptedBuildAction;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -64,8 +62,7 @@ public class RetryStepExecution extends AbstractStepExecutionImpl {
         @Override
         public void onFailure(StepContext context, Throwable t) {
             try {
-                Run run = context.get(Run.class);
-                if (run != null && t instanceof FlowInterruptedException) {
+                if (t instanceof FlowInterruptedException) {
                     for (CauseOfInterruption cause : ((FlowInterruptedException) t).getCauses()) {
                         if (cause instanceof CauseOfInterruption.UserInterruption) {
                             context.onFailure(t);

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/RetryStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/RetryStep/help.html
@@ -1,4 +1,5 @@
 <div>
     Retry the block (up to N times) if any exception happens during its body execution.
     If an exception happens on the final attempt then it will lead to aborting the build (unless it is caught and processed somehow).
+    User aborts of the build are <em>not</em> caught.
 </div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/RetryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/RetryStepTest.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests {@link RetryStep}.
+ */
+public class RetryStepTest {
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test(timeout = 50000)
+    @Issue("JENKINS-41276")
+    public void abortShouldNotRetry() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "int count = 0; retry(3) { echo 'trying '+(count++); semaphore 'start'; sleep 10; echo 'NotHere' }", false));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("start/1", b);
+        b.doStop();
+        b = r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
+        r.assertLogContains("trying 0", b);
+        r.assertLogContains("Aborted by anonymous", b);
+        r.assertLogNotContains("trying 1", b);
+        r.assertLogNotContains("trying 2", b);
+        r.assertLogNotContains("NotHere", b);
+
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/RetryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/RetryStepTest.java
@@ -12,8 +12,6 @@ import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.io.IOException;
-
 import static org.junit.Assert.*;
 
 /**
@@ -31,7 +29,7 @@ public class RetryStepTest {
     public void abortShouldNotRetry() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "int count = 0; retry(3) { echo 'trying '+(count++); semaphore 'start'; echo 'NotHere' }", true));
+                "int count = 0; retry(3) { echo 'trying '+(count++); semaphore 'start'; echo 'NotHere' } echo 'NotHere'", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("start/1", b);
         b.doStop();

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/RetryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/RetryStepTest.java
@@ -31,7 +31,7 @@ public class RetryStepTest {
     public void abortShouldNotRetry() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "int count = 0; retry(3) { echo 'trying '+(count++); semaphore 'start'; sleep 10; echo 'NotHere' }", false));
+                "int count = 0; retry(3) { echo 'trying '+(count++); semaphore 'start'; echo 'NotHere' }", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("start/1", b);
         b.doStop();


### PR DESCRIPTION
[JENKINS-41276](https://issues.jenkins-ci.org/browse/JENKINS-41276)

Supersedes #34. Downstream of https://github.com/jenkinsci/workflow-step-api-plugin/pull/20 and https://github.com/jenkinsci/workflow-job-plugin/pull/36.

@reviewbybees