### PR TITLE
Use Functions.printThrowable to provide more legible stack traces in 2.43+

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.workflow.steps;
 import com.google.common.collect.ImmutableSet;
 import hudson.AbortException;
 import hudson.Extension;
+import hudson.Functions;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -106,7 +107,7 @@ public final class CatchErrorStep extends Step {
                         fie.handle(context.get(Run.class), listener);
                         r = fie.getResult();
                     } else {
-                        t.printStackTrace(listener.getLogger());
+                        listener.getLogger().println(Functions.printThrowable(t).trim()); // TODO 2.43+ use Functions.printStackTrace
                     }
                     context.get(Run.class).setResult(r);
                     context.onSuccess(null);

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.workflow.steps;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
+import hudson.Functions;
 import hudson.model.TaskListener;
 import jenkins.model.CauseOfInterruption;
 
@@ -76,7 +77,7 @@ public class RetryStepExecution extends AbstractStepExecutionImpl {
                     if (t instanceof AbortException) {
                         l.error(t.getMessage());
                     } else {
-                        t.printStackTrace(l.error("Execution failed"));
+                        l.error("Execution failed").println(Functions.printThrowable(t).trim()); // TODO 2.43+ use Functions.printStackTrace
                     }
                     l.getLogger().println("Retrying");
                     context.newBodyInvoker().withCallback(this).start();


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jenkins/pull/1485.

@reviewbybees