### PR TITLE
[JENKINS-27094] writeFile encoding parameter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
@@ -91,7 +91,7 @@ public final class WriteFileStep extends Step {
         }
 
         @Override protected Void run() throws Exception {
-            getContext().get(FilePath.class).child(step.file).write(step.text, /* TODO consider specifying encoding */ null);
+            getContext().get(FilePath.class).child(step.file).write(step.text, step.encoding);
             return null;
         }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/ReadWriteFileStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/ReadWriteFileStepTest.java
@@ -74,7 +74,6 @@ public class ReadWriteFileStepTest {
     public void readAndwriteFileUsesCorrectEncoding() throws Exception
     {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        boolean win = Functions.isWindows();
         p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
                         "  def text = 'HELLO'\n" +
@@ -92,7 +91,6 @@ public class ReadWriteFileStepTest {
     @Test
     public void testKnownCharsetRoundtrip() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        boolean win = Functions.isWindows();
         p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
                         "  def text = 'HELLO'\n" +


### PR DESCRIPTION
[JENKINS-27094](https://issues.jenkins-ci.org/browse/JENKINS-27094)

Added in the missing handling to WriteFileStep to have it properly implement the encoding parameter plus a couple of tests to make sure it's working.