### PR TITLE
Mention the default units for the timeout step.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help.html
@@ -1,5 +1,6 @@
 <div>
-    Executes the code inside the block with a determined time out limit.
-    If the time limit is reached, an exception is thrown, which leads in aborting 
-    the build (unless it is caught and processed somehow).
+    Executes the code inside the block with a determined timeout limit.
+    If the time limit is reached, an exception is thrown, which aborts
+    the build (unless it is caught and processed somehow).  The default
+    unit is 'MINUTES'.
 </div>


### PR DESCRIPTION
src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStep.java uses
'MINUTES' as the default units.

Also, improved the language slightly.