### PR TITLE
[JENKINS-45101] argumentsToString implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
-        <workflow-step-api-plugin.version>2.11</workflow-step-api-plugin.version>
+        <workflow-step-api-plugin.version>2.12-20170630.151937-1</workflow-step-api-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/27 -->
         <workflow-cps-plugin.version>2.32</workflow-cps-plugin.version>
         <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
-        <workflow-step-api-plugin.version>2.12-20170630.151937-1</workflow-step-api-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/27 -->
+        <workflow-step-api-plugin.version>2.12</workflow-step-api-plugin.version>
         <workflow-cps-plugin.version>2.32</workflow-cps-plugin.version>
         <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.30</version>
+        <version>2.31</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,7 +64,7 @@
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
         <workflow-step-api-plugin.version>2.11</workflow-step-api-plugin.version>
-        <workflow-cps-plugin.version>2.30</workflow-cps-plugin.version>
+        <workflow-cps-plugin.version>2.32</workflow-cps-plugin.version>
         <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
     </properties>
     <dependencies>
@@ -156,6 +156,12 @@
             <artifactId>mock-javamail</artifactId>
             <version>1.9</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
@@ -173,6 +179,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
             <version>1.28</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>ansicolor</artifactId>
+            <version>0.5.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
@@ -125,7 +125,8 @@ public final class CoreStep extends Step {
         }
 
         @Override public String argumentsToString(Map<String, Object> namedArgs) {
-            return super.argumentsToString(delegateArguments(namedArgs.get("delegate")));
+            Map<String, Object> delegateArguments = delegateArguments(namedArgs.get("delegate"));
+            return delegateArguments != null ? super.argumentsToString(delegateArguments) : null;
         }
 
         @SuppressWarnings("unchecked")

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
@@ -36,15 +36,17 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
-
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-
+import javax.annotation.CheckForNull;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
-
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -120,6 +122,27 @@ public final class CoreStep extends Step {
 
         @Override public Set<? extends Class<?>> getRequiredContext() {
             return ImmutableSet.of(Run.class, FilePath.class, Launcher.class, TaskListener.class);
+        }
+
+        @Override public String argumentsToString(Map<String, Object> namedArgs) {
+            return super.argumentsToString(delegateArguments(namedArgs.get("delegate")));
+        }
+
+        @SuppressWarnings("unchecked")
+        static @CheckForNull Map<String, Object> delegateArguments(@CheckForNull Object delegate) {
+            if (delegate instanceof UninstantiatedDescribable) {
+                // TODO JENKINS-45101 getStepArgumentsAsString does not resolve its arguments
+                // thus delegate.model == null and we cannot inspect DescribableModel.soleRequiredParameter
+                // thus for, e.g., `junit testResults: '*.xml', keepLongStdio: true` we will get null
+                return new HashMap<>(((UninstantiatedDescribable) delegate).getArguments());
+            } else if (delegate instanceof Map) {
+                Map<String, Object> r = new HashMap<>();
+                r.putAll((Map) delegate);
+                r.remove(DescribableModel.CLAZZ);
+                return r;
+            } else {
+                return null;
+            }
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
@@ -162,7 +162,8 @@ public class CoreWrapperStep extends Step {
         }
 
         @Override public String argumentsToString(Map<String, Object> namedArgs) {
-            return super.argumentsToString(CoreStep.DescriptorImpl.delegateArguments(namedArgs.get("delegate")));
+            Map<String, Object> delegateArguments = CoreStep.DescriptorImpl.delegateArguments(namedArgs.get("delegate"));
+            return delegateArguments != null ? super.argumentsToString(delegateArguments) : null;
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
@@ -161,6 +161,10 @@ public class CoreWrapperStep extends Step {
             return ImmutableSet.of(Run.class, FilePath.class, Launcher.class, TaskListener.class, EnvVars.class);
         }
 
+        @Override public String argumentsToString(Map<String, Object> namedArgs) {
+            return super.argumentsToString(CoreStep.DescriptorImpl.delegateArguments(namedArgs.get("delegate")));
+        }
+
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvStep.java
@@ -138,6 +138,27 @@ public class EnvStep extends Step {
             return Collections.emptySet();
         }
 
+        @Override public String argumentsToString(Map<String, Object> namedArgs) {
+            Object overrides = namedArgs.get("overrides");
+            if (overrides instanceof List) {
+                StringBuilder b = new StringBuilder();
+                for (Object pair : (List) overrides) {
+                    if (pair instanceof String) {
+                        int idx = ((String) pair).indexOf('=');
+                        if (idx > 0) {
+                            if (b.length() > 0) {
+                                b.append(", ");
+                            }
+                            b.append(((String) pair).substring(0, idx));
+                        }
+                    }
+                }
+                return b.toString();
+            } else {
+                return null;
+            }
+        }
+
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/MailStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/MailStep.java
@@ -28,6 +28,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import jenkins.plugins.mailer.tasks.MimeMessageBuilder;
 
@@ -113,6 +114,11 @@ public class MailStep extends Step {
 
         @Override public Set<? extends Class<?>> getRequiredContext() {
             return Collections.singleton(TaskListener.class);
+        }
+
+        @Override public String argumentsToString(Map<String, Object> namedArgs) {
+            Object subject = namedArgs.get("subject");
+            return subject instanceof String ? (String) subject : null;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PwdStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PwdStep.java
@@ -29,6 +29,7 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.slaves.WorkspaceList;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -74,6 +75,10 @@ public class PwdStep extends Step {
 
         @Override public Set<? extends Class<?>> getRequiredContext() {
             return Collections.singleton(FilePath.class);
+        }
+
+        @Override public String argumentsToString(Map<String, Object> namedArgs) {
+            return null; // "true" is not a reasonable description
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/SleepStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/SleepStep.java
@@ -151,5 +151,7 @@ public final class SleepStep extends Step {
             return Collections.singleton(TaskListener.class);
         }
 
+        // TODO argumentsToString should perhaps return "3m" etc.
+
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStep.java
@@ -81,6 +81,8 @@ public class TimeoutStep extends Step implements Serializable {
             return Collections.singleton(TaskListener.class);
         }
 
+        // TODO argumentsToString as for SleepStep
+
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ToolStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ToolStep.java
@@ -36,6 +36,7 @@ import hudson.slaves.NodeSpecific;
 import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.util.ListBoxModel;
+import java.util.Map;
 
 import javax.annotation.CheckForNull;
 
@@ -120,6 +121,11 @@ public final class ToolStep extends Step {
 
         @Override public Set<? extends Class<?>> getRequiredContext() {
             return ImmutableSet.of(TaskListener.class, EnvVars.class, Node.class);
+        }
+
+        @Override public String argumentsToString(Map<String, Object> namedArgs) {
+            Object name = namedArgs.get("name");
+            return name instanceof String ? (String) name : null;
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
@@ -28,6 +28,7 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -77,6 +78,11 @@ public final class WriteFileStep extends Step {
 
         @Override public Set<? extends Class<?>> getRequiredContext() {
             return Collections.singleton(FilePath.class);
+        }
+
+        @Override public String argumentsToString(Map<String, Object> namedArgs) {
+            Object file = namedArgs.get("file");
+            return file instanceof String ? (String) file : null;
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep.java
@@ -30,6 +30,7 @@ import hudson.FilePath;
 import hudson.Util;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import java.util.Map;
 import java.util.Set;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.flow.StashManager;
@@ -128,6 +129,11 @@ public class StashStep extends Step {
 
         @Override public Set<? extends Class<?>> getRequiredContext() {
             return ImmutableSet.of(Run.class, FilePath.class, TaskListener.class);
+        }
+
+        @Override public String argumentsToString(Map<String, Object> namedArgs) {
+            Object name = namedArgs.get("name");
+            return name instanceof String ? (String) name : null;
         }
 
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
@@ -32,9 +32,14 @@ import hudson.tasks.junit.TestResultAction;
 import java.util.List;
 import javax.mail.internet.InternetAddress;
 import jenkins.plugins.mailer.tasks.i18n.Messages;
+import org.hamcrest.Matchers;
 import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
+import org.jenkinsci.plugins.workflow.graphanalysis.NodeStepTypePredicate;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import static org.junit.Assert.*;
@@ -108,12 +113,15 @@ public class CoreStepTest {
                 + "    writeFile text: '''<testsuite name='a'><testcase name='a1'/><testcase name='a2'><error>a2 failed</error></testcase></testsuite>''', file: 'a.xml'\n"
                 + "    writeFile text: '''<testsuite name='b'><testcase name='b1'/><testcase name='b2'/></testsuite>''', file: 'b.xml'\n"
                 + "    junit '*.xml'\n"
-                + "}"));
+                + "}", true));
         WorkflowRun b = r.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
         TestResultAction a = b.getAction(TestResultAction.class);
         assertNotNull(a);
         assertEquals(4, a.getTotalCount());
         assertEquals(1, a.getFailCount());
+        List<FlowNode> coreStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("step"));
+        assertThat(coreStepNodes, Matchers.hasSize(1));
+        assertEquals("*.xml", ArgumentsAction.getStepArgumentsAsString(coreStepNodes.get(0)));
     }
 
     @Test public void javadoc() throws Exception {
@@ -122,9 +130,12 @@ public class CoreStepTest {
                   "node {\n"
                 + "    writeFile text: 'hello world', file: 'docs/index.html'\n"
                 + "    step([$class: 'JavadocArchiver', javadocDir: 'docs'])\n"
-                + "}"));
-        r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                + "}", true));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals("hello world", r.createWebClient().getPage(p, "javadoc/").getWebResponse().getContentAsString());
+        List<FlowNode> coreStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("step"));
+        assertThat(coreStepNodes, Matchers.hasSize(1));
+        assertEquals("docs", ArgumentsAction.getStepArgumentsAsString(coreStepNodes.get(0)));
     }
 
     @Test public void mailer() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashTest.java
@@ -24,8 +24,14 @@
 
 package org.jenkinsci.plugins.workflow.support.steps.stash;
 
+import java.util.List;
+import org.hamcrest.Matchers;
+import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.StashManager;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
+import org.jenkinsci.plugins.workflow.graphanalysis.NodeStepTypePredicate;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
@@ -109,5 +115,8 @@ public class StashTest {
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("Stashed 0 file(s)", b);
         assertEquals("{}", StashManager.stashesOf(b).toString());
+        List<FlowNode> coreStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("stash"));
+        assertThat(coreStepNodes, Matchers.hasSize(1));
+        assertEquals("whatever", ArgumentsAction.getStepArgumentsAsString(coreStepNodes.get(0)));
     }
 }


### PR DESCRIPTION
[JENKINS-45101](https://issues.jenkins-ci.org/browse/JENKINS-45101)

Downstream of https://github.com/jenkinsci/workflow-step-api-plugin/pull/27.

Does not cover every case. Most notably,

```groovy
junit testResults: '*.xml', keepLongStdio: true
```

is not supported, because this would require changes in `workflow-api`. (`argumentsToString` is currently given an unresolved map, which `workflow-basic-steps` _could_ resolve in the same manner as `ArgumentsAction.getResolvedArguments`, but then it would be duplicating code which is also due for a rewrite as described in comments there.) Good enough for now.

@reviewbybees