### PR TITLE
Add an optional initialRecurrencePeriod arg to the waitUntil() step.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep.java
@@ -49,7 +49,7 @@ public final class WaitForConditionStep extends Step {
 
     @DataBoundSetter
     public void setInitialRecurrencePeriod(long initialRecurrencePeriod) {
-        this.initialRecurrencePeriod = Math.min(initialRecurrencePeriod, MAX_RECURRENCE_PERIOD);
+        this.initialRecurrencePeriod = Math.max(MIN_RECURRENCE_PERIOD, Math.min(initialRecurrencePeriod, MAX_RECURRENCE_PERIOD));
     }
 
     long getInitialRecurrencePeriod() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep.java
@@ -36,13 +36,28 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import jenkins.util.Timer;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 public final class WaitForConditionStep extends Step {
 
+    static final long MIN_RECURRENCE_PERIOD = 250; // ¼s
+    static final long MAX_RECURRENCE_PERIOD = 15000; // ¼min
+
+    private long initialRecurrencePeriod = MIN_RECURRENCE_PERIOD;
+
     @DataBoundConstructor public WaitForConditionStep() {}
 
+    @DataBoundSetter
+    public void setInitialRecurrencePeriod(long initialRecurrencePeriod) {
+        this.initialRecurrencePeriod = Math.min(initialRecurrencePeriod, MAX_RECURRENCE_PERIOD);
+    }
+
+    long getInitialRecurrencePeriod() {
+        return initialRecurrencePeriod;
+    }
+
     @Override public StepExecution start(StepContext context) throws Exception {
-        return new Execution(context);
+        return new Execution(context, initialRecurrencePeriod);
     }
 
     public static final class Execution extends AbstractStepExecutionImpl {
@@ -56,12 +71,13 @@ public final class WaitForConditionStep extends Step {
          */
         private final String id = UUID.randomUUID().toString();
         private static final float RECURRENCE_PERIOD_BACKOFF = 1.2f;
-        static final long MIN_RECURRENCE_PERIOD = 250; // ¼s
-        static final long MAX_RECURRENCE_PERIOD = 15000; // ¼min
-        long recurrencePeriod = MIN_RECURRENCE_PERIOD;
+        private final long initialRecurrencePeriod;
+        long recurrencePeriod;
 
-        Execution(StepContext context) {
+        Execution(StepContext context, long initialRecurrencePeriod) {
             super(context);
+            this.initialRecurrencePeriod = initialRecurrencePeriod;
+            recurrencePeriod = initialRecurrencePeriod;
         }
 
         @Override public boolean start() throws Exception {
@@ -77,7 +93,7 @@ public final class WaitForConditionStep extends Step {
         }
 
         @Override public void onResume() {
-            recurrencePeriod = MIN_RECURRENCE_PERIOD;
+            recurrencePeriod = initialRecurrencePeriod;
             if (body == null) {
                 // Restarted while waiting for the timer to go off. Rerun now.
                 body = getContext().newBodyInvoker().withCallback(new Callback(id)).start();

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep.java
@@ -71,13 +71,21 @@ public final class WaitForConditionStep extends Step {
          */
         private final String id = UUID.randomUUID().toString();
         private static final float RECURRENCE_PERIOD_BACKOFF = 1.2f;
-        private final long initialRecurrencePeriod;
+        private long initialRecurrencePeriod;
         long recurrencePeriod;
 
         Execution(StepContext context, long initialRecurrencePeriod) {
             super(context);
             this.initialRecurrencePeriod = initialRecurrencePeriod;
             recurrencePeriod = initialRecurrencePeriod;
+        }
+
+        private Object readResolve() {
+            // in case we are deserializing an older version of this object prior to this field being added
+            if (initialRecurrencePeriod == 0) {
+                initialRecurrencePeriod = MIN_RECURRENCE_PERIOD;
+            }
+            return this;
         }
 
         @Override public boolean start() throws Exception {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep/config.jelly
@@ -24,4 +24,8 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core"/>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="initialRecurrencePeriod" title="Initial Recurrence Period Milliseconds">
+        <f:number clazz="positive-number"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep/help-initialRecurrencePeriod.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep/help-initialRecurrencePeriod.html
@@ -1,0 +1,3 @@
+<div>
+    Sets the initial wait period, in milliseconds, between retries.  Defaults to 250ms.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStepTest.java
@@ -61,7 +61,26 @@ public class WaitForConditionStepTest {
                 SemaphoreStep.success("wait/3", true);
                 SemaphoreStep.waitForStart("waited/1", b);
                 SemaphoreStep.success("waited/1", null);
-                story.j.assertLogContains("Will try again after " + Util.getTimeSpanString(WaitForConditionStep.Execution.MIN_RECURRENCE_PERIOD), story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
+                story.j.assertLogContains("Will try again after " + Util.getTimeSpanString(WaitForConditionStep.MIN_RECURRENCE_PERIOD), story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
+            }
+        });
+    }
+
+    @Test public void initialRecurrence() {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition("waitUntil(initialRecurrencePeriod: 999) {semaphore 'wait'}; semaphore 'waited'", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                SemaphoreStep.waitForStart("wait/1", b);
+                SemaphoreStep.success("wait/1", false);
+                SemaphoreStep.waitForStart("wait/2", b);
+                SemaphoreStep.success("wait/2", false);
+                SemaphoreStep.waitForStart("wait/3", b);
+                SemaphoreStep.success("wait/3", true);
+                SemaphoreStep.waitForStart("waited/1", b);
+                SemaphoreStep.success("waited/1", null);
+                story.j.assertLogContains("Will try again after " + Util.getTimeSpanString(999), story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
             }
         });
     }


### PR DESCRIPTION
Starting from 250msec and ramping up through two orders of magnitude for very slow operations causes a lot of log spew. Allow setting the initial recurrence period to something other than the default.  We often set it to 15 seconds, as we know up front that we'll need to wait about a minute for some async operations.