### PR TITLE
[FIXED JENKINS-40333] catchError should still add script approvals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
             <version>1.28</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
@@ -32,6 +32,10 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.util.Set;
+
+import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -107,6 +111,9 @@ public final class CatchErrorStep extends Step {
                         fie.handle(context.get(Run.class), listener);
                         r = fie.getResult();
                     } else {
+                        if (t instanceof RejectedAccessException) {
+                            ScriptApproval.get().accessRejected((RejectedAccessException) t, ApprovalContext.create());
+                        }
                         listener.getLogger().println(Functions.printThrowable(t).trim()); // TODO 2.43+ use Functions.printStackTrace
                     }
                     context.get(Run.class).setResult(r);


### PR DESCRIPTION
[JENKINS-40333](https://issues.jenkins-ci.org/browse/JENKINS-40333)

The output of the build is the same, but if we see a
RejectedAccessException, we add that to ScriptApproval as well.

cc @reviewbybees 