### PR TITLE
[FIXED JENKINS-48138] Log a warning when fileExists called with empty string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.33</version>
+        <version>3.2</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -63,6 +63,7 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>2.7.3</jenkins.version>
+        <java.level>7</java.level>
         <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
         <workflow-cps-plugin.version>2.32</workflow-cps-plugin.version>
         <workflow-support-plugin.version>2.14</workflow-support-plugin.version>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/FileExistsStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/FileExistsStep.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.Set;
 
 
+import hudson.model.TaskListener;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class FileExistsStep extends Step {
@@ -76,6 +78,9 @@ public final class FileExistsStep extends Step {
         }
 
         @Override protected Boolean run() throws Exception {
+            if (StringUtils.isEmpty(file)) {
+                getContext().get(TaskListener.class).getLogger().println(Messages.FileExistsStep_EmptyString());
+            }
         	return getContext().get(FilePath.class).child(file).exists();
         }
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/Messages.properties
@@ -1,3 +1,4 @@
 ArtifactArchiverStepExecution.Deprecated=The 'archive' step is deprecated, please use 'archiveArtifacts' instead."
 ArtifactArchiverStepExecution.NoFiles=No files found to archive for pattern "{0}", continuing.
 ArtifactArchiverStepExecution.NoFilesWithExcludes=No files found to archive for pattern "{0}", excluding "{1}", continuing.
+FileExistsStep.EmptyString=The 'fileExists' step was called with '', the empty string, so the current directory will be checked instead.

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
@@ -41,6 +41,7 @@ import hudson.model.Run;
 import hudson.model.Slave;
 import hudson.model.TaskListener;
 import hudson.slaves.CommandLauncher;
+import hudson.slaves.ComputerLauncher;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
 import hudson.slaves.SlaveComputer;
@@ -267,7 +268,7 @@ public class CoreWrapperStepTest {
     }
     private static class SpecialEnvSlave extends Slave {
         private final Map<String,String> env;
-        SpecialEnvSlave(File remoteFS, CommandLauncher launcher, String nodeName, @Nonnull String labels, Map<String,String> env) throws Descriptor.FormException, IOException {
+        SpecialEnvSlave(File remoteFS, ComputerLauncher launcher, String nodeName, @Nonnull String labels, Map<String,String> env) throws Descriptor.FormException, IOException {
             super(nodeName, nodeName, remoteFS.getAbsolutePath(), 1, Node.Mode.NORMAL, labels, launcher, RetentionStrategy.NOOP, Collections.<NodeProperty<?>>emptyList());
             this.env = env;
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/FileExistsStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/FileExistsStepTest.java
@@ -1,0 +1,32 @@
+package org.jenkinsci.plugins.workflow.steps;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class FileExistsStepTest {
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @Issue("JENKINS-48138")
+    @Test
+    public void emptyStringWarning() {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition("node { fileExists('') }", true));
+                story.j.assertLogContains(Messages.FileExistsStep_EmptyString(), story.j.buildAndAssertSuccess(p));
+            }
+        });
+    }
+}


### PR DESCRIPTION
[JENKINS-48138](https://issues.jenkins-ci.org/browse/JENKINS-48138)

cc @reviewbybees 