### PR TITLE
Add nodesByLabel

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/NodesByLabelStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/NodesByLabelStep.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Joseph Petersen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.Extension;
+import hudson.model.Computer;
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.model.TaskListener;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Obtains a list of node names by their label
+ */
+public class NodesByLabelStep extends Step {
+
+    private final String label;
+
+    @DataBoundConstructor
+    public NodesByLabelStep(String label) {
+        this.label = label;
+    }
+    
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new Execution(label, context);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "nodesByLabel";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "List of node names by their label";
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.singleton(TaskListener.class);
+        }
+    }
+
+    public static class Execution extends SynchronousStepExecution<ArrayList<String>> {
+        
+        @SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification="Only used when starting.")
+        private transient final String label;
+
+        Execution(String label, StepContext context) {
+            super(context);
+            this.label = label;
+        }
+
+        @Override protected ArrayList<String> run() throws Exception {
+            Label aLabel = Label.get(this.label);
+            Set<Node> nodeSet = aLabel.getNodes();
+            PrintStream logger = getContext().get(TaskListener.class).getLogger();
+            ArrayList<String> nodes = new ArrayList<>();
+            for (Node node : nodeSet) {
+                Computer computer = node.toComputer();
+                if (!(computer == null || computer.isOffline())) nodes.add(node.getNodeName());
+            }
+            if (nodes.isEmpty()) {
+                logger.println("Could not find any nodes with '" + label + "' label");
+            } else {
+                logger.println("Found a total of " + nodes.size() + " nodes with the '" + label + "' label");
+            }
+            return nodes;
+        }
+
+        private static final long serialVersionUID = 1L;
+
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/NodesByLabelStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/NodesByLabelStep/config.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * The MIT License
+ *
+ * Copyright (c) 2018, Joseph Petersen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="label" title="Label">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/NodesByLabelStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/NodesByLabelStep/help.html
@@ -1,0 +1,3 @@
+<div>
+    Returns an array of <code>node</code> names with the given label.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/NodesByLabelStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/NodesByLabelStepTest.java
@@ -1,0 +1,129 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Joseph Petersen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.EnvVars;
+import hudson.cli.CLICommandInvoker;
+import hudson.model.Computer;
+import hudson.model.Result;
+import hudson.slaves.DumbSlave;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static hudson.cli.CLICommandInvoker.Matcher.succeededSilently;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class NodesByLabelStepTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    private WorkflowJob job;
+    private WorkflowRun run;
+    private CLICommandInvoker command;
+
+    @Before
+    public void setup() throws Exception {
+        job = r.jenkins.createProject(WorkflowJob.class, "workflow");
+        r.createSlave("dummy1", "a", new EnvVars());
+        r.createSlave("dummy2", "a b", new EnvVars());
+        r.createSlave("dummy3", "a b c", new EnvVars());
+        DumbSlave slave = r.createSlave("dummy4", "a b c d", new EnvVars());
+        slave.toComputer().waitUntilOnline();
+        command = new CLICommandInvoker(r, "disconnect-node");
+        CLICommandInvoker.Result result = command
+                .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
+                .invokeWithArgs("dummy4");
+        assertThat(result, succeededSilently());
+        assertThat(slave.toComputer().isOffline(), equalTo(true));
+    }
+
+    @Test
+    public void test_nodes_by_label_count_a() throws Exception {
+        // leave out the subject
+        job.setDefinition(new CpsFlowDefinition("nodesByLabel('a')", true));
+
+        run = r.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0).get());
+        r.assertLogContains("Found a total of 3 nodes with the 'a' label", run);
+    }
+
+    @Test
+    public void test_nodes_by_label_count_b() throws Exception {
+        job.setDefinition(new CpsFlowDefinition("nodesByLabel('b')", true));
+
+        run = r.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0).get());
+        r.assertLogContains("Found a total of 2 nodes with the 'b' label", run);
+    }
+
+    @Test
+    public void test_nodes_by_label_count_c() throws Exception {
+        job.setDefinition(new CpsFlowDefinition("nodesByLabel('c')", true));
+
+        run = r.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0).get());
+        r.assertLogContains("Found a total of 1 nodes with the 'c' label", run);
+    }
+
+    @Test
+    public void test_nodes_by_label_count_d_offline() throws Exception {
+        job.setDefinition(new CpsFlowDefinition("nodesByLabel('d')", true));
+
+        run = r.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0).get());
+        r.assertLogContains("Could not find any nodes with 'd' label", run);
+    }
+
+    @Test
+    public void test_nodes_by_label_for_loop() throws Exception {
+        job.setDefinition(new CpsFlowDefinition("def nodes = nodesByLabel('a')\n" +
+                "  for (int i = 0; i < nodes.size(); i++) {\n" +
+                "    def n = nodes[i]\n" +
+                "    node(n) {\n" +
+                "      echo \"Hello ${n}\"\n" +
+                "    }\n" +
+                "  }", true));
+        run = r.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0).get());
+        r.assertLogContains("Hello dummy1", run);
+        r.assertLogContains("Hello dummy2", run);
+        r.assertLogContains("Hello dummy3", run);
+    }
+
+    @Test
+    public void test_nodes_by_label_non_existing_label() throws Exception {
+        job.setDefinition(new CpsFlowDefinition("def nodes = nodesByLabel('F')\n", true));
+        run = r.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0).get());
+        r.assertLogContains("Could not find any nodes with 'F' label", run);
+    }
+
+    @Test
+    public void test_nodes_by_label_get_label() {
+        NodesByLabelStep step1 = new NodesByLabelStep("a");
+        Assert.assertEquals(step1.getLabel(), "a");
+    }
+}


### PR DESCRIPTION
I had this in our shared library using either JSON API or `@NonCPS`. This helps by adding it to the basics. it enables us to use a group of nodes to be maintained through Jenkins.

Naming is open to suggestion 🐳 

Use case:
```groovy
@Library('widex') _
def branches = [:]

def nodeNames = nodesByLabel 'macOS'
def XcodeVersion = '9.2'

nodeNames.each { nodeName ->
  branches[nodeName] = {
    node(nodeName) {
      stage("Install Xcode ${XcodeVersion} for ${nodeName}") {
        timeout(time:60, unit:'MINUTES') {
          withCredentials([
            usernamePassword(credentialsId: 'widex.appleid', passwordVariable: 'XCODE_INSTALL_PASSWORDb', usernameVariable: 'XCODE_INSTALL_USER')
          ]) {
            sh "xcversion update"
            sh "xcversion install '${XcodeVersion}' --no-progress"
          }
        }
      }
    }
  }
}

parallel branches
```