### PR TITLE
[JENKINS-52313] Add Base64 encoding to ReadFileStep and WriteFileStep for binary data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
         <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
         <workflow-cps-plugin.version>2.32</workflow-cps-plugin.version>
         <workflow-support-plugin.version>2.14</workflow-support-plugin.version>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ReadFileStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ReadFileStep.java
@@ -62,6 +62,11 @@ public final class ReadFileStep extends Step {
         return encoding;
     }
 
+    /**
+     * Set the encoding to be used when reading the file. If the specified value is null or
+     * whitespace-only, then the platform default encoding will be used. Binary resources can be
+     * loaded as a Base64-encoded string by specifying {@code Base64} as the encoding.
+     */
     @DataBoundSetter public void setEncoding(String encoding) {
         this.encoding = Util.fixEmptyAndTrim(encoding);
     }
@@ -100,7 +105,7 @@ public final class ReadFileStep extends Step {
                 if (BASE64_ENCODING.equals(step.encoding)) {
                     return Base64.getEncoder().encodeToString(IOUtils.toByteArray(is));
                 } else {
-                    return IOUtils.toString(is, step.encoding);
+                    return IOUtils.toString(is, step.encoding); // The platform default is used if encoding is null.
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ReadFileStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ReadFileStep.java
@@ -33,11 +33,14 @@ import java.util.Collections;
 import java.util.Set;
 
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 public final class ReadFileStep extends Step {
+
+    /*package*/ static final String BASE64_ENCODING = "Base64";
 
     private final String file;
     private String encoding;
@@ -94,7 +97,11 @@ public final class ReadFileStep extends Step {
 
         @Override protected String run() throws Exception {
             try (InputStream is = getContext().get(FilePath.class).child(step.file).read()) {
-                return IOUtils.toString(is, step.encoding);
+                if (BASE64_ENCODING.equals(step.encoding)) {
+                    return Base64.encodeBase64String(IOUtils.toByteArray(is));
+                } else {
+                    return IOUtils.toString(is, step.encoding);
+                }
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ReadFileStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ReadFileStep.java
@@ -29,11 +29,11 @@ import hudson.FilePath;
 import hudson.Util;
 
 import java.io.InputStream;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Set;
 
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -98,7 +98,7 @@ public final class ReadFileStep extends Step {
         @Override protected String run() throws Exception {
             try (InputStream is = getContext().get(FilePath.class).child(step.file).read()) {
                 if (BASE64_ENCODING.equals(step.encoding)) {
-                    return Base64.encodeBase64String(IOUtils.toByteArray(is));
+                    return Base64.getEncoder().encodeToString(IOUtils.toByteArray(is));
                 } else {
                     return IOUtils.toString(is, step.encoding);
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
@@ -27,12 +27,12 @@ package org.jenkinsci.plugins.workflow.steps;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
 
-import org.apache.commons.codec.binary.Base64;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -100,7 +100,7 @@ public final class WriteFileStep extends Step {
         @Override protected Void run() throws Exception {
             FilePath file = getContext().get(FilePath.class).child(step.file);
             if (ReadFileStep.BASE64_ENCODING.equals(step.encoding)) {
-                file.write().write(Base64.decodeBase64(step.text));
+                file.write().write(Base64.getDecoder().decode(step.text));
             } else {
                 file.write(step.text, step.encoding);
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 
 
+import org.apache.commons.codec.binary.Base64;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -97,7 +98,12 @@ public final class WriteFileStep extends Step {
         }
 
         @Override protected Void run() throws Exception {
-            getContext().get(FilePath.class).child(step.file).write(step.text, step.encoding);
+            FilePath file = getContext().get(FilePath.class).child(step.file);
+            if (ReadFileStep.BASE64_ENCODING.equals(step.encoding)) {
+                file.write().write(Base64.decodeBase64(step.text));
+            } else {
+                file.write(step.text, step.encoding);
+            }
             return null;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
@@ -59,6 +59,12 @@ public final class WriteFileStep extends Step {
         return encoding;
     }
 
+    /**
+     * Set the encoding to be used when writing the file. If the specified value is null or
+     * whitespace-only, then the platform default encoding will be used. If the text is a
+     * Base64-encoded string, the decoded binary data can be written to the file by specifying
+     * {@code Base64} as the encoding.
+     */
     @DataBoundSetter public void setEncoding(String encoding) {
         this.encoding = Util.fixEmptyAndTrim(encoding);
     }
@@ -102,7 +108,7 @@ public final class WriteFileStep extends Step {
             if (ReadFileStep.BASE64_ENCODING.equals(step.encoding)) {
                 file.write().write(Base64.getDecoder().decode(step.text));
             } else {
-                file.write(step.text, step.encoding);
+                file.write(step.text, step.encoding); // The platform default is used if encoding is null.
             }
             return null;
         }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/ReadFileStep/help-encoding.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/ReadFileStep/help-encoding.html
@@ -1,0 +1,5 @@
+<div>
+    The encoding to use when reading the file.
+    If left blank, the platform default encoding will be used.
+    Binary files can be read into a Base64-encoded string by specifying &quot;Base64&quot; as the encoding.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/WriteFileStep/help-encoding.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/WriteFileStep/help-encoding.html
@@ -1,0 +1,6 @@
+<div>
+    The target encoding for the file.
+    If left blank, the platform default encoding will be used.
+    If the text is a Base64-encoded string, the decoded binary data can be written
+    to the file by specifying &quot;Base64&quot; as the encoding.
+</div>


### PR DESCRIPTION
See [JENKINS-52313](https://issues.jenkins-ci.org/browse/JENKINS-52313).

Adds support for a special encoding named "Base64" that can be used for binary files. Useful in tandem with jenkinsci/workflow-cps-global-lib-plugin#48 to copy binary resource files from shared libraries to the workspace.

~I'd prefer to use Java 8's Base64 API but the plugin is currently building against Java 7 so I am using commons-compress via Jenkins core.~ Baseline has been updated to Java 8 and Jenkins 2.60.3 to use the new Base64 API.

Also, I'm not sure if we want to add features to the stable branch or if that should be limited to the bleeding-edge branch, so just let me know if I need to rebase the PR.

@reviewbybees @jennbriden