### PR TITLE
Update parent for auto-reincrementalification when releasing

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-3</version>
+    <version>1.0-beta-5</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.15</version>
+        <version>3.19</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
(Note: this is against master, not stable) Picks up [version 3.18](https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md#318) of the parent pom which automatically runs the `incrementals:reincrementalify` Maven goal when preparing the plugin for the next development version after a release.