### PR TITLE
Fix typo in TimeoutStep's config.jelly

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/config.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry field="time" title="$%{Timeout}">
+    <f:entry field="time" title="${%Timeout}">
         <f:number clazz="positive-number"/>
     </f:entry>
     <f:entry field="unit" title="${%Unit}">


### PR DESCRIPTION
A small typo in #61 caused the text to be displayed as literally `$%{Timeout}`.