### PR TITLE
JENKINS-53305 Workaround for email error

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/MailStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/MailStep.java
@@ -148,10 +148,10 @@ public class MailStep extends Step {
             // JENKINS-53305 - contextClassLoader can _sometimes_ be null, which causes the obtuse error message
             // javax.activation.UnsupportedDataTypeException: no object DCH for MIME type multipart/mixed;
             // I can't see why this would ever be valid and don't know the cause, but if we encounter it, then set
-            // it to the uberclass loader
+            // it to the Jenkins loader
             if (Thread.currentThread().getContextClassLoader() == null) {
-                LOGGER.log(Level.WARNING, "contextClassLoader is null - re-setting to uberClassLoader");
-                Thread.currentThread().setContextClassLoader(Jenkins.getInstance().getPluginManager().uberClassLoader);
+                LOGGER.log(Level.WARNING, "contextClassLoader is null - re-setting to Jenkins.class.classLoader");
+                Thread.currentThread().setContextClassLoader(Jenkins.class.getClassLoader());
             }
             Transport.send(mimeMessage);
             return null;


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-53305

_sometimes_ when emailing as part of a pipeline, we can get the error:
```
avax.mail.MessagingException: IOException while sending message;
  nested exception is:
	javax.activation.UnsupportedDataTypeException: no object DCH for MIME type multipart/mixed; 
	boundary="----=_Part_190_367171778.1535728877636"
	at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1141)
	at javax.mail.Transport.send0(Transport.java:195)
	at javax.mail.Transport.send(Transport.java:124)
	at org.jenkinsci.plugins.workflow.steps.MailStep$MailStepExecution.run(MailStep.java:142)
	at org.jenkinsci.plugins.workflow.steps.MailStep$MailStepExecution.run(MailStep.java:128)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1$1.call(SynchronousNonBlockingStepExecution.java:50)
	at hudson.security.ACL.impersonate(ACL.java:290)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1.run(SynchronousNonBlockingStepExecution.java:47)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: javax.activation.UnsupportedDataTypeException: no object DCH for MIME type multipart/mixed; 
	boundary="----=_Part_190_367171778.1535728877636"
	at javax.activation.ObjectDataContentHandler.writeTo(DataHandler.java:896)
	at javax.activation.DataHandler.writeTo(DataHandler.java:317)
	at javax.mail.internet.MimeBodyPart.writeTo(MimeBodyPart.java:1476)
	at javax.mail.internet.MimeMessage.writeTo(MimeMessage.java:1772)
	at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1099)
	... 12 more
```

This happens when `Thread.currentThread.getContextClassLoader()` is `null`. Why it should be `null` and what is setting it, I don't know. However, although this error only happens _sometimes_, I can recreate it every time by explicitly setting the class loader to `null` as a test.

This is a workaround, not a fix, so don't mind if it doesn't get merged, but am leaving it here for discussion or in case others are hitting the same problem. At the very least, if this doesn't get merged and you are hitting this  problem, you can do a custom build of the plugin using this PR and hopefully get less failures from your Jenkins instance.

@reviewbybees