### PR TITLE
Fix file leak in WriteFileStep when using Base64 encoding

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.workflow.steps;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
+import java.io.OutputStream;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
@@ -106,7 +107,9 @@ public final class WriteFileStep extends Step {
         @Override protected Void run() throws Exception {
             FilePath file = getContext().get(FilePath.class).child(step.file);
             if (ReadFileStep.BASE64_ENCODING.equals(step.encoding)) {
-                file.write().write(Base64.getDecoder().decode(step.text));
+                try (OutputStream os = file.write()) {
+                    os.write(Base64.getDecoder().decode(step.text));
+                }
             } else {
                 file.write(step.text, step.encoding); // The platform default is used if encoding is null.
             }


### PR DESCRIPTION
Fixes a file leak specific to Base64 encoding introduced by #66. Similar to jenkinsci/workflow-cps-global-lib-plugin#52.

@reviewbybees