### PR TITLE
Avoid deprecated api usage

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
@@ -113,7 +113,7 @@ public final class CoreStep extends Step {
             return r;
         }
         private <T extends Describable<T>,D extends Descriptor<T>> void populate(List<Descriptor<?>> r, Class<T> c) {
-            for (Descriptor<?> d : Jenkins.getActiveInstance().getDescriptorList(c)) {
+            for (Descriptor<?> d : Jenkins.get().getDescriptorList(c)) {
                 if (SimpleBuildStep.class.isAssignableFrom(d.clazz)) {
                     r.add(d);
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
@@ -145,7 +145,7 @@ public class CoreWrapperStep extends Step {
         // getPropertyType("delegate").getApplicableDescriptors() does not work, because extension lists do not work on subtypes.
         public Collection<BuildWrapperDescriptor> getApplicableDescriptors() {
             Collection<BuildWrapperDescriptor> r = new ArrayList<>();
-            for (BuildWrapperDescriptor d : Jenkins.getActiveInstance().getExtensionList(BuildWrapperDescriptor.class)) {
+            for (BuildWrapperDescriptor d : Jenkins.get().getExtensionList(BuildWrapperDescriptor.class)) {
                 if (SimpleBuildWrapper.class.isAssignableFrom(d.clazz)) {
                     r.add(d);
                 }


### PR DESCRIPTION
This is based on the analysis https://ci.jenkins.io/job/Infra/job/deprecated-usage-in-plugins/job/master/566/artifact/output/usage-by-plugin.html.