### PR TITLE
[JENKINS-54078] JEP-210 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,8 @@
         <workflow-support-plugin.version>2.21-beta-1</workflow-support-plugin.version>
         <workflow-api-plugin.version>2.30-beta-1</workflow-api-plugin.version>
         <useBeta>true</useBeta>
+        <git-plugin.version>4.0.0-beta3</git-plugin.version>
+        <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -204,13 +206,33 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>${git-plugin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>${scm-api-plugin.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>${git-plugin.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>scm-api</artifactId>
-                <version>2.2.6</version>
+                <version>${scm-api-plugin.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.22-rc713.c51e25cf0eef</version> <!-- TODO https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/75 -->
+            <version>2.24</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.19</version>
+        <version>3.25</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -67,9 +67,9 @@
         <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
         <workflow-step-api-plugin.version>2.15</workflow-step-api-plugin.version>
-        <workflow-cps-plugin.version>2.32</workflow-cps-plugin.version>
-        <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
-        <workflow-api-plugin.version>2.28</workflow-api-plugin.version>
+        <workflow-cps-plugin.version>2.58-beta-1</workflow-cps-plugin.version>
+        <workflow-support-plugin.version>2.21-beta-1</workflow-support-plugin.version>
+        <workflow-api-plugin.version>2.30-beta-1</workflow-api-plugin.version>
         <useBeta>true</useBeta>
     </properties>
     <dependencies>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.14</version>
+            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -121,13 +121,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.10</version>
+            <version>2.26-beta-1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.3</version>
+            <version>2.22-rc713.c51e25cf0eef</version> <!-- TODO https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/75 -->
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.28</version>
+            <version>1.46</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -205,4 +205,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>scm-api</artifactId>
+                <version>2.2.6</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,9 @@
         <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
         <workflow-step-api-plugin.version>2.15</workflow-step-api-plugin.version>
-        <workflow-cps-plugin.version>2.58-beta-1</workflow-cps-plugin.version>
-        <workflow-support-plugin.version>2.21-beta-1</workflow-support-plugin.version>
-        <workflow-api-plugin.version>2.30-beta-1</workflow-api-plugin.version>
+        <workflow-cps-plugin.version>2.58</workflow-cps-plugin.version>
+        <workflow-support-plugin.version>2.21</workflow-support-plugin.version>
+        <workflow-api-plugin.version>2.30</workflow-api-plugin.version>
         <useBeta>true</useBeta>
         <git-plugin.version>4.0.0-beta3</git-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.26-beta-1</version>
+            <version>2.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import jenkins.model.CauseOfInterruption;
 import jenkins.security.SlaveToMasterCallable;
 import jenkins.util.Timer;
@@ -243,7 +242,8 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
 
         private static final long serialVersionUID = 1L;
 
-        private final String id;
+        /** non-null unless running from an old deserialized ConsoleLogFilterImpl */
+        private final @CheckForNull String id;
 
         ResetTimer(String id) {
             this.id = id;
@@ -251,7 +251,7 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
 
         @Override public Void call() throws RuntimeException {
             StepExecution.applyAll(TimeoutStepExecution.class, e -> {
-                if (id.equals(e.id)) {
+                if (id == null || id.equals(e.id)) {
                     e.resetTimer();
                 }
                 return null;
@@ -264,7 +264,7 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
     private static class ConsoleLogFilterImpl extends ConsoleLogFilter implements /* TODO Remotable */ Serializable {
         private static final long serialVersionUID = 1L;
 
-        private final @Nonnull String id;
+        private final @CheckForNull String id;
         private transient @CheckForNull Channel channel;
 
         ConsoleLogFilterImpl(String id) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/EnvStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/EnvStepTest.java
@@ -90,9 +90,9 @@ public class EnvStepTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                     "parallel a: {\n" +
-                    "  node {withEnv(['TOOL=aloc']) {semaphore 'a'; isUnix() ? sh('echo TOOL=$TOOL') : bat('echo TOOL=%TOOL%')}}\n" +
+                    "  node {withEnv(['TOOL=aloc']) {semaphore 'a'; isUnix() ? sh('echo a TOOL=$TOOL') : bat('echo a TOOL=%TOOL%')}}\n" +
                     "}, b: {\n" +
-                    "  node {withEnv(['TOOL=bloc']) {semaphore 'b'; isUnix() ? sh('echo TOOL=$TOOL') : bat('echo TOOL=%TOOL%')}}\n" +
+                    "  node {withEnv(['TOOL=bloc']) {semaphore 'b'; isUnix() ? sh('echo b TOOL=$TOOL') : bat('echo b TOOL=%TOOL%')}}\n" +
                     "}", true));
                 WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();
                 SemaphoreStep.waitForStart("a/1", b);
@@ -100,8 +100,8 @@ public class EnvStepTest {
                 SemaphoreStep.success("a/1", null);
                 SemaphoreStep.success("b/1", null);
                 story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b));
-                story.j.assertLogContains("[a] TOOL=aloc", b);
-                story.j.assertLogContains("[b] TOOL=bloc", b);
+                story.j.assertLogContains("a TOOL=aloc", b);
+                story.j.assertLogContains("b TOOL=bloc", b);
             }
         });
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.steps;
 
+import hudson.Functions;
 import hudson.model.Result;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
@@ -43,6 +44,7 @@ import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.*;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
@@ -236,6 +238,24 @@ public class TimeoutStepTest extends Assert {
                 story.j.assertLogContains("JustHere!", b);
                 story.j.assertLogNotContains("ShouldNot!", b);
             }
+        });
+    }
+
+    @Test
+    public void activityRemote() {
+        assumeFalse(Functions.isWindows()); // TODO create analogue using bat
+        story.then(r -> {
+            r.createSlave();
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("" +
+                     "node('!master') {\n" +
+                     "  timeout(time:5, unit:'SECONDS', activity: true) {\n" +
+                     "    sh 'set +x; echo NotHere; sleep 3; echo NotHereYet; sleep 3; echo JustHere; sleep 10; echo ShouldNot'\n" +
+                     "  }\n" +
+                     "}\n", true));
+            WorkflowRun b = r.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0));
+            story.j.assertLogContains("JustHere", b);
+            story.j.assertLogNotContains("ShouldNot", b);
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
@@ -262,7 +262,6 @@ public class TimeoutStepTest extends Assert {
         });
     }
 
-    @Ignore("TODO")
     @Issue("JENKINS-54078")
     @Test public void activityGit() {
         story.then(r -> {


### PR DESCRIPTION
Demonstrates that https://github.com/abayer/workflow-basic-steps-plugin/pull/1 was a necessary amendment to https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/62 in order to make `timeout` work properly with remote durable tasks as of JEP-210. If you disable that fix using

```diff
diff --git a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
index 20f2f21..0b4933c 100644
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
@@ -250,11 +250,6 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
             this.callback = callback;
         }
 
-        private Object writeReplace() {
-            Channel ch = Channel.current();
-            return ch == null ? this : new ConsoleLogFilterImpl(ch.export(ResetCallback.class, callback));
-        }
-
         @Override
         public OutputStream decorateLogger(@SuppressWarnings("rawtypes") Run build, final OutputStream logger)
                 throws IOException, InterruptedException {
```

then the build fails as expected:

```
[Pipeline] sh
[p] Running shell script
[Pipeline] }
[Pipeline] // timeout
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
java.io.NotSerializableException: hudson.model.Executor
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
	at …
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at hudson.remoting.UserRequest._serialize(UserRequest.java:264)
	at hudson.remoting.UserRequest.serialize(UserRequest.java:273)
	at hudson.remoting.UserRequest.<init>(UserRequest.java:101)
	at hudson.remoting.Channel.call(Channel.java:953)
	at hudson.Launcher$RemoteLauncher.launch(Launcher.java:1052)
	at hudson.Launcher$ProcStarter.start(Launcher.java:449)
	at org.jenkinsci.plugins.durabletask.BourneShellScript.launchWithCookie(BourneShellScript.java:185)
	at org.jenkinsci.plugins.durabletask.FileMonitoringTask.launch(FileMonitoringTask.java:98)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.start(DurableTaskStep.java:266)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeStep(DSL.java:270)
	at …
Caused: java.io.IOException: Unable to serialize hudson.Launcher$RemoteLaunchCallable@2b4d80f
	at hudson.remoting.UserRequest.serialize(UserRequest.java:275)
	at hudson.remoting.UserRequest.<init>(UserRequest.java:101)
	at hudson.remoting.Channel.call(Channel.java:953)
	at hudson.Launcher$RemoteLauncher.launch(Launcher.java:1052)
	at hudson.Launcher$ProcStarter.start(Launcher.java:449)
	at org.jenkinsci.plugins.durabletask.BourneShellScript.launchWithCookie(BourneShellScript.java:185)
	at org.jenkinsci.plugins.durabletask.FileMonitoringTask.launch(FileMonitoringTask.java:98)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.start(DurableTaskStep.java:266)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeStep(DSL.java:270)
	at …
Finished: FAILURE
```

Some more discussion: https://github.com/jenkinsci/workflow-support-plugin/pull/15#discussion_r210586067

----

And then amends that change for [JENKINS-54078](https://issues.jenkins-ci.org/browse/JENKINS-54078) because it turns out (as I just happened to learn yesterday in https://github.com/jenkinsci/pipeline-log-fluentd-cloudwatch-plugin/pull/8/commits/f66f63810e16929f5dd3f61ca2489df492e9ef8e!) that `Channel.export` is pretty much useless; for some reason I have yet to track down, `FilePath` calls from the Git plugin (but not those from, say, the `sh` step) trigger collection of references.