### PR TITLE
[JENKINS-54323] Add setBuildInfo step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ work
 .classpath
 .project
 .settings/
+
+.DS_Store

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep.java
@@ -1,0 +1,207 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.util.ListBoxModel;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public final class SetBuildInfoStep extends Step {
+
+    private final RunPropertySetter setting;
+
+    @DataBoundConstructor
+    public SetBuildInfoStep(RunPropertySetter setting) {
+        this.setting = setting;
+    }
+
+    public RunPropertySetter getSetting() {
+        return setting;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new Execution(this, context);
+    }
+
+    private static class Execution extends SynchronousStepExecution<Void> {
+        private static final long serialVersionUID = 1;
+
+        private transient final SetBuildInfoStep step;
+
+        Execution(SetBuildInfoStep step, StepContext context) {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        public Void run() throws Exception {
+            Run r = getContext().get(Run.class);
+            if (r != null) {
+                step.setting.set(r);
+            }
+            return null;
+        }
+    }
+
+    @Extension public static final class DescriptorImpl extends StepDescriptor {
+        @Override
+        public String getFunctionName() {
+            return "setBuildInfo";
+        }
+
+        @Override public String getDisplayName() {
+            return "Modify properties of the current build";
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.singleton(Run.class);
+        }
+    }
+
+    @Restricted(NoExternalUse.class)
+    public static abstract class RunPropertySetter extends AbstractDescribableImpl<RunPropertySetter> {
+        public abstract void set(Run r) throws Exception;
+        public static abstract class DescriptorImpl extends Descriptor<RunPropertySetter> { }
+    }
+
+    public static class DescriptionSetter extends RunPropertySetter {
+        private final String description;
+
+        @DataBoundConstructor
+        public DescriptionSetter(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        @Override
+        public void set(Run r) throws Exception {
+            r.setDescription(description);
+        }
+
+        @Symbol("description")
+        @Extension public static class DescriptorImpl extends RunPropertySetter.DescriptorImpl {
+            @Override public String getDisplayName() {
+                return "Description";
+            }
+        }
+    }
+
+    public static class DisplayNameSetter extends RunPropertySetter {
+        private final String displayName;
+
+        @DataBoundConstructor
+        public DisplayNameSetter(String displayName) {
+            this.displayName = displayName;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        @Override
+        public void set(Run r) throws Exception {
+            r.setDisplayName(displayName);
+        }
+
+        @Symbol("displayName")
+        @Extension public static class DescriptorImpl extends RunPropertySetter.DescriptorImpl {
+            @Override public String getDisplayName() {
+                return "Display Name";
+            }
+        }
+    }
+
+    public static class KeepLogSetter extends RunPropertySetter {
+        private final boolean keepLog;
+
+        @DataBoundConstructor
+        public KeepLogSetter(boolean keepLog) {
+            this.keepLog = keepLog;
+        }
+
+        public boolean getKeepLog() {
+            return keepLog;
+        }
+
+        @Override
+        public void set(Run r) throws Exception {
+            r.keepLog(keepLog);
+        }
+
+        @Symbol("keepLog")
+        @Extension public static class DescriptorImpl extends RunPropertySetter.DescriptorImpl {
+            @Override public String getDisplayName() {
+                return "Keep Log";
+            }
+        }
+    }
+
+    public static class ResultSetter extends RunPropertySetter {
+        private final String result;
+
+        @DataBoundConstructor
+        public ResultSetter(String result) {
+            this.result = result;
+        }
+
+        public String getResult() {
+            return result;
+        }
+
+        @Override
+        public void set(Run r) throws Exception {
+            r.setResult(Result.fromString(result));
+        }
+
+        @Symbol("result")
+        @Extension public static class DescriptorImpl extends RunPropertySetter.DescriptorImpl {
+            @Override public String getDisplayName() {
+                return "Result";
+            }
+            public ListBoxModel doFillResultItems() {
+                return Stream.of(Result.SUCCESS, Result.UNSTABLE, Result.FAILURE, Result.NOT_BUILT, Result.ABORTED)
+                        .map(r -> new ListBoxModel.Option(r.toString(), r.toString()))
+                        .collect(Collectors.toCollection(ListBoxModel::new));
+            }
+        }
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/DescriptionSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/DescriptionSetter/config.jelly
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2018 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <!-- TODO: JENKINS-25130 would get rid of the need to set help and add helpArea -->
+    <f:entry title="Description" help="${descriptor.helpFile}">
+        <f:textbox field="description"/>
+    </f:entry>
+    <f:helpArea/>
+</j:jelly>
+

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/DescriptionSetter/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/DescriptionSetter/help.html
@@ -1,0 +1,3 @@
+<div>
+    Set the description for the current build.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/DisplayNameSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/DisplayNameSetter/config.jelly
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2018 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <!-- TODO: JENKINS-25130 would get rid of the need to set help and add helpArea -->
+    <f:entry title="Display Name" help="${descriptor.helpFile}">
+        <f:textbox field="displayName"/>
+    </f:entry>
+    <f:helpArea/>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/DisplayNameSetter/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/DisplayNameSetter/help.html
@@ -1,0 +1,3 @@
+<div>
+    Set the display name for the current build.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/KeepLogSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/KeepLogSetter/config.jelly
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2018 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <!-- TODO: JENKINS-25130 would get rid of the need to set help and add helpArea -->
+    <f:entry title="Keep Build Records Forever" help="${descriptor.helpFile}">
+        <f:checkbox field="keepLog" default="true"/>
+    </f:entry>
+    <f:helpArea/>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/KeepLogSetter/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/KeepLogSetter/help.html
@@ -1,0 +1,6 @@
+<div>
+    Set whether to keep the build records (logs, artifacts, etc.) of this build
+    forever. If set to <code>false</code>, build records will be removed
+    according to the rules specified in the <em>Discard Old Builds</em> section
+    of the job's configuration.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/ResultSetter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/ResultSetter/config.jelly
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2018 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <!-- TODO: JENKINS-25130 would get rid of the need to set help and add helpArea -->
+    <f:entry title="Result" help="${descriptor.helpFile}">
+        <f:select field="result"/>
+    </f:entry>
+    <f:helpArea/>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/ResultSetter/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/ResultSetter/help.html
@@ -1,0 +1,5 @@
+<div>
+    Set the build result. Note that the build result can only get worse, i.e.
+    calling <code>setBuildInfo(result('SUCCESS'))</code> while the current build
+    result is FAILURE will not change the build result.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/config.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2018 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="">
+        <f:dropdownDescriptorSelector field="setting" title="Setting" />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStep/help.html
@@ -1,0 +1,3 @@
+<div>
+    Configure settings for the current build such as the description and display name.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/SetBuildInfoStepTest.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class SetBuildInfoStepTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void setDescription() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        String description = "Modified Description";
+        p.setDefinition(new CpsFlowDefinition("setBuildInfo(description('" + description + "'))", true));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertThat(b.getDescription(), equalTo(description));
+    }
+
+    @Test public void setDisplayName() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        String displayName = "Modified Display Name";
+        p.setDefinition(new CpsFlowDefinition("setBuildInfo(displayName('" + displayName + "'))", true));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertThat(b.getDisplayName(), equalTo(displayName));
+    }
+
+    @Test public void setKeepLog() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        boolean keepLog = true;
+        p.setDefinition(new CpsFlowDefinition("setBuildInfo(keepLog(" + keepLog + "))", true));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertThat(b.isKeepLog(), equalTo(keepLog));
+    }
+
+    @Test public void setResult() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        Result result = Result.ABORTED;
+        p.setDefinition(new CpsFlowDefinition("setBuildInfo(result('" + result.toString() + "'))", true));
+        WorkflowRun b = r.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0));
+        assertThat(b.getResult(), equalTo(result));
+    }
+
+}


### PR DESCRIPTION
See [JENKINS-54323](https://issues.jenkins-ci.org/browse/JENKINS-54323). Complements https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/71. 

This PR adds a dedicated step named `setBuildInfo` (I don't feel too strongly about that name, so let me know if you'd prefer something else) for setting `Run.description`, `Run.displayName`, `Run.keepLog`, and `Run.result`. This step would get rid of one of the use cases that currently requires `RunWrapper`.

Right now, I've created a single step that takes a specified `Describable` in its constructor:

    setBuildInfo(description('description here'))
    setBuildInfo(displayName('display name here'))
    setBuildInfo(keepLog(true))
    setBuildInfo(result('FAILURE'))

The other approach that would make sense to me would be to have a dedicated step for each field:

    setBuildDescription('description here')
    setBuildDisplayName('display name here')
    setBuildKeepLog(true)
    setBuildResult('FAILURE')

I chose the describable approach because I initially allowed a list to be passed to the step, but that didn't seem very likely to be useful in practice, so I simplified it, at which point a dedicated step for each field seems like the better approach. I'm putting this up as-is to see what people think, so let me know if you have a strong preference for either implementation.

@reviewbybees 