### PR TITLE
[JENKINS-54607] Use Grace_Period for timeout

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
@@ -177,8 +177,7 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
             listener().getLogger().println("Cancelling nested steps due to timeout");
             body.cancel(new ExceededTimeout());
             forcible = true;
-            long now = System.currentTimeMillis();
-            end = now + GRACE_PERIOD;
+            timeout = GRACE_PERIOD;
             resetTimer();
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
@@ -42,6 +42,8 @@ import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable.Row;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.*;
+
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -374,7 +376,7 @@ public class TimeoutStepTest extends Assert {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("timeout(time: 15, unit: 'SECONDS') {unkillable()}", true));
                 story.j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0).get());
-                assert p.getLastBuild().getDuration() < 30_000; // 30s
+                assertThat(p.getLastBuild().getDuration(), lessThan(29_000L)); // 29 seconds
             }
         });
     }


### PR DESCRIPTION
See [JENKINS-54607](https://issues.jenkins-ci.org/browse/JENKINS-54607).

This PR enables the intended behaviour that the timeout step sleeps for a predefined `GRACE_PERIOD` till the body will be forcefully canceled.
Otherwise a `timeout(10)` results in waiting 10 additional minutes till the execution will be forcefully canceled