### PR TITLE
[JENKINS-54607] Merge #76 from stable into master

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
@@ -45,7 +45,7 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
     private BodyExecution body;
     private transient ScheduledFuture<?> killer;
 
-    private final long timeout;
+    private long timeout;
     private long end = 0;
 
     /** Used to track whether this is timing out on inactivity without needing to reference {@link #step}. */

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
@@ -189,8 +189,7 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
             listener().getLogger().println("Cancelling nested steps due to timeout");
             body.cancel(new ExceededTimeout());
             forcible = true;
-            long now = System.currentTimeMillis();
-            end = now + GRACE_PERIOD;
+            timeout = GRACE_PERIOD;
             resetTimer();
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
@@ -44,6 +44,8 @@ import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable.Row;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.*;
+
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.*;
 import org.junit.runners.model.Statement;
@@ -371,7 +373,7 @@ public class TimeoutStepTest extends Assert {
                 getContext().get(TaskListener.class).getLogger().println("ignoring " + cause);
             }
         }
-        @TestExtension("unresponsiveBody") public static class DescriptorImpl extends StepDescriptor {
+        @TestExtension({"unresponsiveBody", "gracePeriod"}) public static class DescriptorImpl extends StepDescriptor {
             @Override public String getFunctionName() {
                 return "unkillable";
             }
@@ -404,6 +406,18 @@ public class TimeoutStepTest extends Assert {
                 WorkflowRun b = p.getBuildByNumber(1);
                 RunListener.fireStarted(b, TaskListener.NULL);
                 story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b));
+            }
+        });
+    }
+
+    @Issue("JENKINS-54607")
+    @Test public void gracePeriod() {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition("timeout(time: 15, unit: 'SECONDS') {unkillable()}", true));
+                story.j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0).get());
+                assertThat(p.getLastBuild().getDuration(), lessThan(29_000L)); // 29 seconds
             }
         });
     }


### PR DESCRIPTION
See #76 ([JENKINS-54607](https://issues.jenkins-ci.org/browse/JENKINS-54607)).

The timeout field was changed from non-final to final by #74, so the plugin would not compile after merging the fix from `stable` into `master`. It doesn't look like there is any reason that the field _needs_ to be final, so I've changed it back and things appear to be working nicely.

CC @Xaseron