### PR TITLE
Fixing minor mistakes in messages

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/Messages.properties
@@ -1,4 +1,4 @@
-ArtifactArchiverStepExecution.Deprecated=The 'archive' step is deprecated, please use 'archiveArtifacts' instead."
+ArtifactArchiverStepExecution.Deprecated=The archive step is deprecated, please use archiveArtifacts instead.
 ArtifactArchiverStepExecution.NoFiles=No files found to archive for pattern "{0}", continuing.
 ArtifactArchiverStepExecution.NoFilesWithExcludes=No files found to archive for pattern "{0}", excluding "{1}", continuing.
-FileExistsStep.EmptyString=The 'fileExists' step was called with '', the empty string, so the current directory will be checked instead.
+FileExistsStep.EmptyString=The fileExists step was called with the empty string, so the current directory will be checked instead.

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/Messages.properties
@@ -1,4 +1,4 @@
 ArtifactArchiverStepExecution.Deprecated=The archive step is deprecated, please use archiveArtifacts instead.
-ArtifactArchiverStepExecution.NoFiles=No files found to archive for pattern "{0}", continuing.
-ArtifactArchiverStepExecution.NoFilesWithExcludes=No files found to archive for pattern "{0}", excluding "{1}", continuing.
+ArtifactArchiverStepExecution.NoFiles=No files found to archive for pattern "{0}"; continuing.
+ArtifactArchiverStepExecution.NoFilesWithExcludes=No files found to archive for pattern "{0}", excluding "{1}"; continuing.
 FileExistsStep.EmptyString=The fileExists step was called with the empty string, so the current directory will be checked instead.


### PR DESCRIPTION
619226b270cae47130a724a517ef8a5b3d6bac6f introduced a stray `"` I guess copied from the Java string (use one of the IDE plugins for Jenkins which handle this!), and also I guess you forgot that `MessageFormat` treats `'` as a metacharacter unless doubled up to escape (generally better to avoid `'` and use `‘’` or something else). Currently prints:

```
[Pipeline] archive
The archive step is deprecated, please use archiveArtifacts instead."
```