### PR TITLE
[JENKINS-58322] feat: IgnoreError step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/IgnoreErrorStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/IgnoreErrorStep.java
@@ -1,0 +1,121 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import com.google.common.collect.ImmutableSet;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.FormValidation;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.util.Set;
+
+/**
+ * Runs a block, and if that block fails, prints a message, marks the build as {@link Result#SUCCESS}, adds a
+ * {@link WarningAction} to the step, and then continues execution normally.
+ *
+ * @see CatchErrorStep
+ */
+public class IgnoreErrorStep extends Step implements CatchExecutionOptions {
+    private static final long serialVersionUID = 1L;
+
+    private final String message;
+    private boolean catchInterruptions = true;
+
+    @DataBoundConstructor
+    public IgnoreErrorStep(String message) {
+        message = Util.fixEmptyAndTrim(message);
+        if (message == null) {
+            throw new IllegalArgumentException("A non-empty message is required");
+        }
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public Result getBuildResultOnError() {
+        return Result.SUCCESS;
+    }
+
+    @Override
+    public Result getStepResultOnError() {
+        return Result.UNSTABLE;
+    }
+
+    @Override
+    public boolean isCatchInterruptions() {
+        return catchInterruptions;
+    }
+
+    @DataBoundSetter
+    public void setCatchInterruptions(boolean catchInterruptions) {
+        this.catchInterruptions = catchInterruptions;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new CatchErrorStep.Execution(context, this);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+        @Override
+        public String getFunctionName() {
+            return "ignoreError";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Catch error and set build result as success and stage result to unstable";
+        }
+
+        @Override public boolean takesImplicitBlockArgument() {
+            return true;
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return ImmutableSet.of(FlowNode.class, Run.class, TaskListener.class);
+        }
+
+        public FormValidation doCheckMessage(@QueryParameter String message) {
+            if (Util.fixEmptyAndTrim(message) == null) {
+                return FormValidation.error("Message must be non-empty");
+            }
+            return FormValidation.ok();
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/IgnoreErrorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/IgnoreErrorStepTest.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.jenkinsci.plugins.workflow.steps.CatchErrorStepTest.assertCatchError;
+
+@Issue("JENKINS-58322")
+public class IgnoreErrorStepTest {
+    @ClassRule public static BuildWatcher w = new BuildWatcher();
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void smokes() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "ignoreError('caught error') {\n" +
+                "  error 'oops'\n" +
+                "}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertCatchError(r, b, Result.SUCCESS, Result.UNSTABLE, true);
+    }
+
+    @Test public void requiresMessage() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "ignoreError() {\n" +
+                "  error 'oops'\n" +
+                "}", true));
+        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        r.assertLogContains("A non-empty message is required", b);
+    }
+
+    @Test public void catchesTimeoutsByDefault() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "timeout(time: 250, unit: 'MILLISECONDS') {\n" +
+                "  ignoreError('caught error') {\n" +
+                "    sleep 1\n" +
+                "  }\n" +
+                "}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertCatchError(r, b, Result.ABORTED, Result.ABORTED, true);
+    }
+
+    @Test public void canAvoidCatchingTimeoutsWithOption() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "timeout(time: 250, unit: 'MILLISECONDS') {\n" +
+                "  ignoreError(message: 'caught error', catchInterruptions: false) {\n" +
+                "    sleep 1\n" +
+                "  }\n" +
+                "}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertCatchError(r, b, Result.ABORTED, null, false);
+    }
+
+    @Test public void catchesAttemptsToStopBuildByDefault() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "ignoreError('caught error') {\n" +
+                "  semaphore 'ready'\n" +
+                "}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("ready/1", b);
+        b.doStop();
+        assertCatchError(r, b, Result.ABORTED, Result.ABORTED, true);
+    }
+
+    @Test public void canAvoidCatchingAttemptsToStopBuildWithOption() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "ignoreError(message: 'caught error', catchInterruptions: false) {\n" +
+                "  semaphore 'ready'\n" +
+                "}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("ready/1", b);
+        b.doStop();
+        assertCatchError(r, b, Result.ABORTED, null, false);
+    }
+}


### PR DESCRIPTION
see [JENKINS-58322](https://issues.jenkins-ci.org/browse/JENKINS-58322)

On the issue [JENKINS-45579](https://issues.jenkins-ci.org/browse/JENKINS-45579) @dwnusbaum has added a couple of really nice steps `WarnErrorStep`and `CatchErrorStep`, this improvement is a continuation of his work (mostly copy so I've maintained the same license header) to add another user case, when you need to ignore the failure of a stage but you want to mar the build as successful and it is not possible to use `CatchErrorStep` or you want to simplify your stage code, `ignoreErrors` option would mark the build as `SUCCESS` and the stage as `UNSTABLE`.


