### PR TITLE
Use Functions.printStackTrace

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
@@ -66,7 +66,7 @@ public class RetryStepExecution extends AbstractStepExecutionImpl {
                     if (t instanceof AbortException) {
                         l.error(t.getMessage());
                     } else {
-                        l.error("Execution failed").println(Functions.printThrowable(t).trim()); // TODO 2.43+ use Functions.printStackTrace
+                        Functions.printStackTrace(t, l.error("Execution failed"));
                     }
                     l.getLogger().println("Retrying");
                     context.newBodyInvoker().withCallback(this).start();


### PR DESCRIPTION
In #36, a call to `Functions.printThrowable` was added with a TODO comment to switch to `Functions.printStackTrace` when the baseline was bumped to 2.43+. The baseline is now 2.150.1, so this TODO can be completed.

This code didn't have any test coverage, so I added a simple integration test which passes both before and after the changes in `src/main`.