### PR TITLE
Use WorkspaceList.tempDir

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PwdStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PwdStep.java
@@ -83,11 +83,6 @@ public class PwdStep extends Step {
 
     }
 
-    // TODO use 1.652 use WorkspaceList.tempDir
-    private static FilePath tempDir(FilePath ws) {
-        return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
-    }
-
     public static class Execution extends SynchronousStepExecution<String> {
         
         @SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification="Only used when starting.")
@@ -100,7 +95,7 @@ public class PwdStep extends Step {
 
         @Override protected String run() throws Exception {
             FilePath cwd = getContext().get(FilePath.class);
-            return (tmp ? tempDir(cwd) : cwd).getRemote();
+            return (tmp ? WorkspaceList.tempDir(cwd) : cwd).getRemote();
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/PwdStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/PwdStepTest.java
@@ -51,16 +51,11 @@ public class PwdStepTest {
         r.assertLogContains("cwd='" + r.jenkins.getWorkspaceFor(p) + "'", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }
 
-    // TODO use 1.652 use WorkspaceList.tempDir
-    private static FilePath tempDir(FilePath ws) {
-        return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
-    }
-
     @Test public void tmp() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node {echo \"tmp='${pwd tmp: true}'\"}", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("tmp='" + tempDir(r.jenkins.getWorkspaceFor(p)) + "'", b);
+        r.assertLogContains("tmp='" + WorkspaceList.tempDir(r.jenkins.getWorkspaceFor(p)) + "'", b);
         List<FlowNode> coreStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("pwd"));
         assertThat(coreStepNodes, Matchers.hasSize(1));
         assertEquals(null, ArgumentsAction.getStepArgumentsAsString(coreStepNodes.get(0)));


### PR DESCRIPTION
In ad40c76, the `PwdStep#tempDir` method was added with a TODO comment to switch to `WorkspaceList.tempDir` when the baseline was bumped to 1.652. The baseline is now 2.150.1, so this TODO can be completed.

I confirmed that the code in question is exercised by `PwdStepTest#tmp`.