### PR TITLE
Consistently use sandbox for CpsFlowDefinitions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/ArtifactArchiverStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/ArtifactArchiverStepTest.java
@@ -36,7 +36,7 @@ public class ArtifactArchiverStepTest {
                 "  archive 'm*'",
                 "  unarchive(mapping:['msg':'msg.out'])",
                 "  archive 'msg.out'",
-                "}"), "\n")));
+                "}"), "\n"), true));
 
 
         // get the build going, and wait until workflow pauses
@@ -70,7 +70,7 @@ public class ArtifactArchiverStepTest {
                 "    unarchive mapping: ['a/' : '.']",
                 "    echo \"${readFile 'a/1'}/${readFile 'a/b/2'}\"",
                 "  }",
-                "}"), "\n")));
+                "}"), "\n"), true));
         WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
         VirtualFile archivedFile = b.getArtifactManager().root().child("a/b/2");
         assertTrue(archivedFile.exists());

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
@@ -97,7 +97,7 @@ public class CoreWrapperStepTest {
                 slaveEnv.put("HOME", "/home/jenkins");
                 createSpecialEnvSlave(story.j, "slave", "", slaveEnv);
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition("node('slave') {mock {semaphore 'restarting'; echo \"groovy PATH=${env.PATH}:\"; sh 'echo shell PATH=$PATH:'}}"));
+                p.setDefinition(new CpsFlowDefinition("node('slave') {mock {semaphore 'restarting'; echo \"groovy PATH=${env.PATH}:\"; sh 'echo shell PATH=$PATH:'}}", true));
                 WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();
                 SemaphoreStep.waitForStart("restarting/1", b);
             }
@@ -159,7 +159,7 @@ public class CoreWrapperStepTest {
                     "    show 'after'\n" +
                     "  }\n" +
                     "  show 'outside'\n" +
-                    "}"));
+                    "}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
                 story.j.assertLogContains("received initial", b);
                 story.j.assertLogContains("groovy before wrapped", b);
@@ -194,7 +194,7 @@ public class CoreWrapperStepTest {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition("node {echo 'outside #1'; wrap([$class: 'WrapperWithLogger']) {echo 'inside the block'}; echo 'outside #2'}"));
+                p.setDefinition(new CpsFlowDefinition("node {echo 'outside #1'; wrap([$class: 'WrapperWithLogger']) {echo 'inside the block'}; echo 'outside #2'}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
                 story.j.assertLogContains("outside #1", b);
                 story.j.assertLogContains("outside #2", b);

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/DeleteDirStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/DeleteDirStepTest.java
@@ -100,7 +100,7 @@ public class DeleteDirStepTest {
     private String runAndGetWorkspaceDir(String flow) throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
 
-        p.setDefinition(new CpsFlowDefinition(flow));
+        p.setDefinition(new CpsFlowDefinition(flow, true));
         r.assertBuildStatusSuccess(p.scheduleBuild2(0));
 
         FilePath ws = r.jenkins.getWorkspaceFor(p);

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/ReadWriteFileStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/ReadWriteFileStepTest.java
@@ -78,7 +78,7 @@ public class ReadWriteFileStepTest {
                 "  echo \"test.txt - FileExists: ${fileExists('test.txt')}\" \n" +
                 "  writeFile file: 'test2.txt', text:'content of file' \n" +
                 "  echo \"test2.txt - FileExists: ${fileExists('test2.txt')}\" \n" +
-                "}"));
+                "}", true));
 
 		WorkflowRun run = p.scheduleBuild2(0).get();
 		r.assertLogContains("test.txt - FileExists: false", run); 
@@ -97,7 +97,7 @@ public class ReadWriteFileStepTest {
                         "  writeFile file: 'f1', text: text, encoding: 'utf-32le'\n" +
                         "  def text2 = readFile file: 'f1', encoding: 'utf-32le'\n" +
                         "  echo text2\n" +
-                        "}"));
+                        "}", true));
         r.assertLogContains("HELLO", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }
 
@@ -114,7 +114,7 @@ public class ReadWriteFileStepTest {
                         "  writeFile file: 'f1', text: '¤', encoding: 'iso-8859-1'\n" +
                         "  def text2 = readFile file: 'f1', encoding: 'iso-8859-15'\n" +
                         "  echo text2\n" +
-                        "}"));
+                        "}", true));
         r.assertLogContains("€", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }
 
@@ -130,7 +130,7 @@ public class ReadWriteFileStepTest {
                         "  def base64Text = readFile file: 'binary-file', encoding: 'Base64'\n" +
                         "  writeFile file: 'round-trip-base64', text: base64Text, encoding: 'Base64'\n" +
                         "  semaphore 'bytes-checked'\n" +
-                        "}"));
+                        "}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("file-created/1", b);
         byte[] bytes = {0x48, 0x45, 0x4c, 0x4c, 0x4f, (byte) 0x80, (byte) 0xec, (byte) 0xf4, 0x00, 0x0d, 0x1b};

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStepTest.java
@@ -159,7 +159,7 @@ public class WaitForConditionStepTest {
             @SuppressWarnings("SleepWhileInLoop")
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition("waitUntil {semaphore 'wait'}; echo 'finished waiting'", /* TODO sandbox fails on `staticMethod org.jenkinsci.plugins.workflow.cps.Safepoint safepoint`; why? */false));
+                p.setDefinition(new CpsFlowDefinition("waitUntil {semaphore 'wait'}; echo 'finished waiting'", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait/1", b);
                 final List<WaitForConditionStep.Execution> executions = new ArrayList<>();

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/WithContextStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/WithContextStepTest.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.steps;
 
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.ClassRule;
@@ -39,7 +40,8 @@ public class WithContextStepTest {
 
     @Test public void pushd() throws Exception {
         WorkflowJob p = r.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("node {withContext(getContext(hudson.FilePath).child('subdir')) {echo(/simulating dir step in ${pwd()}/)}}", false));
+        ScriptApproval.get().approveSignature("method hudson.FilePath child java.lang.String");
+        p.setDefinition(new CpsFlowDefinition("node {withContext(getContext(hudson.FilePath).child('subdir')) {echo(/simulating dir step in ${pwd()}/)}}", true));
         r.assertLogContains("simulating dir step in " + r.jenkins.getWorkspaceFor(p).child("subdir").getRemote(), r.buildAndAssertSuccess(p));
     }
 


### PR DESCRIPTION
While looking at the test suite for this plugin, I noticed the `CpsFlowDefinition`s in the tests don't  consistently use the script security sandbox. In one case a comment was left saying "TODO sandbox fails on `staticMethod org.jenkinsci.plugins.workflow.cps.Safepoint safepoint`; why?", but this comment appears to be out-of-date since the failure no longer occurs on `master` as of the time of this writing. Always using the script security sandbox makes the tests consistent with each other, and it's also a more realistic environment given that the script security sandbox should always be enabled in production.

All existing tests passed when run in the script security sandbox, except for `WithContextStepTest#pushd`. To make this test pass, I approved the `method hudson.FilePath child java.lang.String` signature, which the test calls.