### PR TITLE
Remove usages of deprecated APIs

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
@@ -52,7 +52,7 @@ public class CatchErrorStepTest {
     @Rule public JenkinsRule r = new JenkinsRule();
 
     @Test public void specialStatus() throws Exception {
-        User.get("smrt");
+        User.getById("smrt", true);
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
                 "catchError {\n" +

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/RetryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/RetryStepTest.java
@@ -91,7 +91,7 @@ public class RetryStepTest {
                 "int count = 0; retry(3) { echo 'trying '+(count++); semaphore 'start'; echo 'NotHere' } echo 'NotHere'", true));
         final WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("start/1", b);
-        ACL.impersonate(User.get("dev").impersonate(), new Runnable() {
+        ACL.impersonate(User.getById("dev", true).impersonate(), new Runnable() {
             @Override public void run() {
                 b.getExecutor().doStop();
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/ToolStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/ToolStepTest.java
@@ -33,7 +33,6 @@ import hudson.tools.ToolProperty;
 import java.io.File;
 import java.util.List;
 import java.util.Set;
-import jenkins.model.Jenkins;
 import org.hamcrest.Matchers;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.SymbolLookup;
@@ -63,7 +62,7 @@ public class ToolStepTest {
     @Test public void build() throws Exception {
         Maven.MavenInstallation tool = ToolInstallations.configureMaven3();
         String name = tool.getName();
-        Maven.MavenInstallation.DescriptorImpl desc = Jenkins.getInstance().getDescriptorByType(Maven.MavenInstallation.DescriptorImpl.class);
+        Maven.MavenInstallation.DescriptorImpl desc = r.jenkins.getDescriptorByType(Maven.MavenInstallation.DescriptorImpl.class);
 
         // Defensive - Maven doesn't have a symbol before 2.x, and other tools may still not have symbols after that.
         String type = desc.getId();
@@ -88,7 +87,7 @@ public class ToolStepTest {
     @Test public void toolWithSymbol() throws Exception {
         File toolHome = folder.newFolder("mockTools");
         MockToolWithSymbol tool = new MockToolWithSymbol("mock-tool-with-symbol", toolHome.getAbsolutePath(), JenkinsRule.NO_PROPERTIES);
-        Jenkins.getInstance().getDescriptorByType(MockToolWithSymbol.MockToolWithSymbolDescriptor.class).setInstallations(tool);
+        r.jenkins.getDescriptorByType(MockToolWithSymbol.MockToolWithSymbolDescriptor.class).setInstallations(tool);
 
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node {def home = tool name: '" + tool.getName() + "', type: 'mockToolWithSymbol'\n"
@@ -102,7 +101,7 @@ public class ToolStepTest {
     @Test public void toolWithoutSymbol() throws Exception {
         File toolHome = folder.newFolder("mockTools");
         MockToolWithoutSymbol tool = new MockToolWithoutSymbol("mock-tool-without-symbol", toolHome.getAbsolutePath(), JenkinsRule.NO_PROPERTIES);
-        Jenkins.getInstance().getDescriptorByType(MockToolWithoutSymbol.MockToolWithoutSymbolDescriptor.class).setInstallations(tool);
+        r.jenkins.getDescriptorByType(MockToolWithoutSymbol.MockToolWithoutSymbolDescriptor.class).setInstallations(tool);
 
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node {def home = tool name: '" + tool.getName() + "', type: 'mockToolWithoutSymbol'}",


### PR DESCRIPTION
While perusing the source tree, I noticed a number of deprecated methods:

- The documentation for [`User.get(java.lang.String)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#get-java.lang.String-) states: "This method is deprecated, because it causes unexpected `User` creation by API usage code and causes performance degradation of used to retrieve users by ID. Use [`getById(java.lang.String, boolean)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#getById-java.lang.String-boolean-) when you know you have an ID."
- The documentation for [`ACL.impersonate(org.acegisecurity.Authentication, java.lang.Runnable)`](https://javadoc.jenkins-ci.org/hudson/security/ACL.html#impersonate-org.acegisecurity.Authentication-java.lang.Runnable-) states: "use try with resources and [`as(Authentication)`](https://javadoc.jenkins-ci.org/hudson/security/ACL.html#as-org.acegisecurity.Authentication-)".
- The documentation for [`Jenkins.getInstance()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstance--) states: "This is a historical alias for [`getInstanceOrNull()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstanceOrNull--) but with ambiguous nullability. Use [`get()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#get--) in typical cases."

Accordingly, I replaced any calls to `User.get(java.lang.String` with calls to `User.getById(java.lang.String, boolean`, I replaced any usages of `ACL.impersonate` with usages of try-with-resources and `ACL.as`, and I replaced any usages of `Jenkins.getInstance()` with usages of `JenkinsRule.jenkins`.