### PR TITLE
Added delay capability to retry

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStep.java
@@ -26,26 +26,62 @@ package org.jenkinsci.plugins.workflow.steps;
 
 import hudson.Extension;
 import hudson.model.TaskListener;
+import hudson.util.ListBoxModel;
+
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Executes the body up to N times.
  *
  * @author Kohsuke Kawaguchi
  */
-public class RetryStep extends Step {
+public class RetryStep extends Step implements Serializable {
     
     private final int count;
+    private int timeDelay;
+    private TimeUnit unit = TimeUnit.SECONDS;
+    private boolean useTimeDelay = false;
+    
+    public int left;
 
     @DataBoundConstructor
     public RetryStep(int count) {
         this.count = count;
+        this.left = count;
     }
 
     public int getCount() {
         return count;
+    }
+
+    @DataBoundSetter public void setUseTimeDelay(boolean useTimeDelay) {
+        this.useTimeDelay = useTimeDelay;
+    }
+
+    public boolean isUseTimeDelay() {
+        return useTimeDelay;
+    }
+
+    @DataBoundSetter public void setTimeDelay(int timeDelay) {
+        this.timeDelay = timeDelay;
+    }
+
+    public int getTimeDelay() {
+        return timeDelay;
+    }
+
+    @DataBoundSetter public void setUnit(TimeUnit unit) {
+        this.unit = unit;
+    }
+
+    public TimeUnit getUnit() {
+        return unit;
     }
 
     @Override
@@ -55,7 +91,7 @@ public class RetryStep extends Step {
 
     @Override
     public StepExecution start(StepContext context) throws Exception {
-        return new RetryStepExecution(count, context);
+        return new RetryStepExecution(this, context);
     }
 
     @Extension
@@ -76,6 +112,14 @@ public class RetryStep extends Step {
             return "Retry the body up to N times";
         }
 
+        public ListBoxModel doFillUnitItems() {
+            ListBoxModel r = new ListBoxModel();
+            for (TimeUnit unit : TimeUnit.values()) {
+                r.add(unit.name());
+            }
+            return r;
+        }
+        
         @Override
         public Set<? extends Class<?>> getRequiredContext() {
             return Collections.singleton(TaskListener.class);
@@ -83,4 +127,5 @@ public class RetryStep extends Step {
 
     }
 
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
@@ -3,49 +3,150 @@ package org.jenkinsci.plugins.workflow.steps;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.Functions;
+import hudson.Util;
 import hudson.model.TaskListener;
+
+import java.util.UUID;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+
+import com.google.common.base.Function;
+
+import jenkins.util.Timer;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 public class RetryStepExecution extends AbstractStepExecutionImpl {
-    
-    @SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification="Only used when starting.")
-    private transient final int count;
 
+    @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Only used when starting.")
+    private transient final RetryStep step;
+    private transient final int count;
+    private transient volatile ScheduledFuture<?> task;
+
+    private boolean executing = false;
+    /** Token for {@link #activity} callbacks. */
+    private final String id = UUID.randomUUID().toString();
+
+
+    @Deprecated
     RetryStepExecution(int count, StepContext context) {
         super(context);
-        this.count = count;
+        this.count =count;
+        this.step = null;
     }
 
-    @Override
-    public boolean start() throws Exception {
+    RetryStepExecution(@Nonnull RetryStep step, StepContext context) {
+        super(context);
+        this.step = step;
+        this.count = step.getCount();
+    }
+
+    @Override public boolean start() throws Exception {
         StepContext context = getContext();
-        context.newBodyInvoker()
-            .withCallback(new Callback(count))
-            .start();
+        if(step == null) {
+            context.newBodyInvoker()
+                .withCallback(new Callback(count))
+                .start();
+        } else {
+            executing = true;
+            context.newBodyInvoker()
+                .withCallback(new Callback(id,step))
+                .start();
+        }
         return false;   // execution is asynchronous
     }
+    
+    @Override public void stop(Throwable cause) throws Exception {
+        if (task != null) {
+            task.cancel(false);
+        }
+        super.stop(cause);
+    }
+    
+    @Override public void onResume() {
+        if (!executing && step != null) {
+            // Restarted while waiting for the timer to go off. Rerun now.
+            getContext().newBodyInvoker().withCallback(new Callback(id, step)).start();
+            executing = true;
+        } // otherwise we are in the middle of the body already, so let it run
+    }
 
-    @Override public void onResume() {}
+    private static void retry(final String id, final StepContext context) {
+        StepExecution.applyAll(RetryStepExecution.class, new Function<RetryStepExecution, Void>() {
+            @Override public Void apply(@Nonnull RetryStepExecution execution) {
+                if (execution.id.equals(id)) {
+                    execution.retry(context);
+                }
+                return null;
+            }
+        });
+    }
+
+    private void retry(StepContext perBodyContext) {
+        executing = false;
+        getContext().saveState();
+
+        try {
+            TaskListener l = getContext().get(TaskListener.class);
+            if(step.left>0) {
+                long delay = step.getUnit().toMillis(step.getTimeDelay());
+                l.getLogger().println(
+                    "Will try again after " + 
+                    Util.getTimeSpanString(delay));
+                task = Timer.get().schedule(new Runnable() {
+                    @Override public void run() {
+                        task = null;
+                        try {
+                            l.getLogger().println("Retrying");
+                        } catch (Exception x) {
+                            getContext().onFailure(x);
+                            return;
+                        }
+                        getContext().newBodyInvoker().withCallback(new Callback(id,step)).start();
+                        executing = true;
+                    }
+                }, delay, TimeUnit.MILLISECONDS);
+            }
+        } catch (Throwable p) {
+            getContext().onFailure(p);
+        }
+    }
+
+    @Override public String getStatus() {
+        if (executing) {
+            return "running body";
+        } else if (task == null) {
+            return "no body, no task, not sure what happened";
+        } else if (task.isDone()) {
+            return "scheduled task is done, but no body";
+        } else if (task.isCancelled()) {
+            return "scheduled task was cancelled";
+        } else {
+            return "waiting to rerun; next recurrence period: " + 
+                step.getUnit().toMillis(step.getTimeDelay()) + "ms";
+        }
+    }
 
     private static class Callback extends BodyExecutionCallback {
 
+        private final RetryStep step;
         private int left;
+        private final String id;
 
+        @Deprecated
         Callback(int count) {
             left = count;
+            this.step = null;
+            this.id = "-1";
         }
 
-        /* Could be added, but seems unnecessary, given the message already printed in onFailure:
-        @Override public void onStart(StepContext context) {
-            try {
-                context.get(TaskListener.class).getLogger().println(left + " tries left");
-            } catch (Exception x) {
-                context.onFailure(x);
-            }
+        Callback(String id, RetryStep step) {
+            this.id = id;
+            this.step = step;
+            left = step.getCount();
         }
-        */
 
         @Override
         public void onSuccess(StepContext context, Object result) {
@@ -60,15 +161,20 @@ public class RetryStepExecution extends AbstractStepExecutionImpl {
                     return;
                 }
                 left--;
-                if (left>0) {
+                step.left--;
+                if ((left>0) || (step != null && step.left>0)) {
                     TaskListener l = context.get(TaskListener.class);
                     if (t instanceof AbortException) {
                         l.error(t.getMessage());
                     } else {
                         Functions.printStackTrace(t, l.error("Execution failed"));
                     }
-                    l.getLogger().println("Retrying");
-                    context.newBodyInvoker().withCallback(this).start();
+                    if(step == null || !step.isUseTimeDelay()) {
+                        l.getLogger().println("Retrying");
+                        context.newBodyInvoker().withCallback(this).start();
+                    } else {
+                        RetryStepExecution.retry(id, context);
+                    }
                 } else {
                     // No need to print anything in this case, since it will be thrown up anyway.
                     context.onFailure(t);

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/RetryStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/RetryStep/config.jelly
@@ -28,4 +28,13 @@ THE SOFTWARE.
     <f:entry field="count" title="${%Retry Count}">
         <f:number clazz="positive-number"/>
     </f:entry>
+
+    <f:optionalBlock field="useTimeDelay" inline="true" title="${%Use a time delay between retries.}">
+        <f:entry field="timeDelay" title="${%Sleep between retry}">
+            <f:number clazz="positive-number"/>
+        </f:entry>
+        <f:entry field="unit" title="${%Unit}">
+            <f:select/>
+        </f:entry>
+    </f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/RetryStep/help-useTimeDelay.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/RetryStep/help-useTimeDelay.html
@@ -1,0 +1,3 @@
+<div>
+    Use a time delay in between retries.
+</div>

--- a/src/test/resources/org/jenkinsci/plugins/workflow/steps/RetryStepTest/pipelineOptionsRetryWithTimeout.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/workflow/steps/RetryStepTest/pipelineOptionsRetryWithTimeout.groovy
@@ -1,0 +1,19 @@
+pipeline {
+    agent any
+    options {
+        retry(count: 3, timeDelay: 10, unit: 'SECONDS', useTimeDelay: true)
+    }
+    stages {
+        stage('x') {
+            steps {
+                echo 'Trying!'
+                error('oops')
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Done!'
+        }
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/workflow/steps/RetryStepTest/pipelineRetryStepWithTimeout.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/workflow/steps/RetryStepTest/pipelineRetryStepWithTimeout.groovy
@@ -1,0 +1,18 @@
+pipeline {
+    agent any
+    stages {
+        stage('x') {
+            steps {
+                retry(count: 3, timeDelay: 10, unit: 'SECONDS', useTimeDelay: true) {
+                    echo 'Trying!'
+                    error('oops')
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Done!'
+        }
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/workflow/steps/RetryStepTest/stageOptionsRetryWithTimeout copy.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/workflow/steps/RetryStepTest/stageOptionsRetryWithTimeout copy.groovy
@@ -1,0 +1,19 @@
+pipeline {
+    agent any
+    stages {
+        stage('x') {
+            options {
+                retry(count: 3, timeDelay: 10, unit: 'SECONDS', useTimeDelay: true)
+            }
+            steps {
+                echo 'Trying!'
+                error('oops')
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Done!'
+        }
+    }
+}


### PR DESCRIPTION
In some cases a user wants to add a delay between retries that are performed. While continue to support the original usage of retry, this adds three new attributes to RetryStep: useTimeDelay, timeDelay, and units. If useTimeDelay is true, then the timeDelay will be applied between retries.