### PR TITLE
[JENKINS-59575] Warning about get/withContext

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/WithContextStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/WithContextStep/help.html
@@ -11,3 +11,8 @@
 <p>
     For use from trusted code, such as global libraries, which can manipulate internal Jenkins APIs.
 </p>
+<p>
+    <strong>Do not</strong> attempt to pass objects defined in Groovy;
+    only Java-defined objects are supported.
+    Really you should avoid using this and <code>getContext</code> and just define a <code>Step</code> in a plugin instead.
+</p>


### PR DESCRIPTION
[JENKINS-59575](https://issues.jenkins-ci.org/browse/JENKINS-59575)

If there were a formal way to deprecate a step (beyond `isAdvanced`) I would use it. These steps should never have been defined. I had originally thought to use them with the likes of https://github.com/jenkinsci/workflow-cps-plugin/pull/59.