### PR TITLE
ErrorStep to write error message to console output

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ErrorStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ErrorStep.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.workflow.steps;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.Extension;
+import hudson.model.TaskListener;
 import java.util.Collections;
 import java.util.Set;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -60,6 +61,7 @@ public final class ErrorStep extends Step {
         }
 
         @Override protected Void run() throws Exception {
+            getContext().get(TaskListener.class).getLogger().println(message);
             throw new AbortException(message);
         }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/ErrorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/ErrorStepTest.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2019 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.support.actions.LogStorageAction;
+import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable;
+import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable.Row;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertTrue;
+
+
+public class ErrorStepTest {
+    @ClassRule public static BuildWatcher w = new BuildWatcher();
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void logStorageActionIsPresent() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "error 'oops'\n", true));
+        WorkflowRun run = p.scheduleBuild2(0).waitForStart();
+
+        r.waitForCompletion(run);
+        r.assertBuildStatus(Result.FAILURE, run);
+
+        FlowGraphTable t = new FlowGraphTable(run.getExecution());
+        t.build();
+        boolean errorStepNodePresent = false;
+        for (Row r : t.getRows()) {
+            if (r.getNode() instanceof StepAtomNode) {
+                StepAtomNode a = (StepAtomNode) r.getNode();
+                if (a.getDescriptor().getClass() == ErrorStep.DescriptorImpl.class) {
+                    assertTrue(a.getAction(LogStorageAction.class) != null);
+                    // we want to be sure this Node is present
+                    errorStepNodePresent = true;
+                }
+            }
+        }
+        assertTrue(errorStepNodePresent);
+    }
+}


### PR DESCRIPTION
After this change it is possible to get error message from 'Pipeline Steps' view in log view. It is very useful as it allows to check error messages while build is still running.

Signed-off-by: Artur Harasimiuk <artur.harasimiuk@intel.com>