### PR TITLE
[JENKINS-60354] Use FlowInterruptedException.isActualInterruption to decide if an exception should be rethrown

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(useAci: true)

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.150.1</jenkins.version>
         <java.level>8</java.level>
-        <workflow-step-api-plugin.version>2.22-20191211.162318-1</workflow-step-api-plugin.version> <!-- TODO: https://github.com/jenkinsci/workflow-step-api-plugin/pull/51 -->
+        <workflow-step-api-plugin.version>2.22</workflow-step-api-plugin.version>
         <workflow-cps-plugin.version>2.70</workflow-cps-plugin.version>
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
         <workflow-api-plugin.version>2.34</workflow-api-plugin.version>
@@ -195,7 +195,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-build-step</artifactId>
-            <version>2.11-20191211.174233-1</version> <!-- TODO https://github.com/jenkinsci/pipeline-build-step-plugin/pull/39 -->
+            <version>2.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.150.1</jenkins.version>
         <java.level>8</java.level>
-        <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
+        <workflow-step-api-plugin.version>2.22-20191211.162318-1</workflow-step-api-plugin.version> <!-- TODO: https://github.com/jenkinsci/workflow-step-api-plugin/pull/51 -->
         <workflow-cps-plugin.version>2.70</workflow-cps-plugin.version>
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
         <workflow-api-plugin.version>2.34</workflow-api-plugin.version>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.18</version>
+            <version>1.20</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -190,6 +190,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ansicolor</artifactId>
             <version>0.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>pipeline-build-step</artifactId>
+            <version>2.11-20191211.174233-1</version> <!-- TODO https://github.com/jenkinsci/pipeline-build-step-plugin/pull/39 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
@@ -217,7 +217,7 @@ public final class CatchErrorStep extends Step implements CatchExecutionOptions 
 
             @Override public void onFailure(StepContext context, Throwable t) {
                 try {
-                    if (!options.isCatchInterruptions() && t instanceof FlowInterruptedException) {
+                    if (!options.isCatchInterruptions() && t instanceof FlowInterruptedException && ((FlowInterruptedException)t).isActualInterruption()) {
                         context.onFailure(t);
                         return;
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/RetryStepExecution.java
@@ -55,7 +55,7 @@ public class RetryStepExecution extends AbstractStepExecutionImpl {
         @Override
         public void onFailure(StepContext context, Throwable t) {
             try {
-                if (t instanceof FlowInterruptedException) {
+                if (t instanceof FlowInterruptedException && ((FlowInterruptedException)t).isActualInterruption()) {
                     context.onFailure(t);
                     return;
                 }


### PR DESCRIPTION
See [JENKINS-60354](https://issues.jenkins-ci.org/browse/JENKINS-60354) and https://github.com/jenkinsci/workflow-step-api-plugin/pull/51.