### PR TITLE
JENKINS-60239 Aborted catchError sets build result to ABORTED if fail fast is true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,10 +66,10 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.150.1</jenkins.version>
         <java.level>8</java.level>
-        <workflow-step-api-plugin.version>2.22</workflow-step-api-plugin.version>
-        <workflow-cps-plugin.version>2.70</workflow-cps-plugin.version>
+        <workflow-step-api-plugin.version>2.23-SNAPSHOT</workflow-step-api-plugin.version>
+        <workflow-cps-plugin.version>2.81-SNAPSHOT</workflow-cps-plugin.version>
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
-        <workflow-api-plugin.version>2.34</workflow-api-plugin.version>
+        <workflow-api-plugin.version>2.36</workflow-api-plugin.version>
         <useBeta>true</useBeta>
         <git-plugin.version>4.0.0-beta3</git-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
@@ -111,7 +111,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
             <version>${workflow-cps-plugin.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -183,7 +182,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.58</version>
+            <version>1.63</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Hello,

I like strongly typed solutions but in this case the downside is that I have introduced a new dependency (workflow-cps) which might not be something you want or like.

I could pass a message to the `FailFastException` and check if any cause of interruption has that message (it's not very elegant and hides the dependency on the parallel step).

Daniel