### PR TITLE
Avoid NPE when calling fileExists step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/FileExistsStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/FileExistsStep.java
@@ -78,11 +78,9 @@ public final class FileExistsStep extends Step {
         }
 
         @Override protected Boolean run() throws Exception {
-            if (file == null) {
-                getContext().get(TaskListener.class).getLogger().println(Messages.FileExistsStep_NullString());
-                return getContext().get(FilePath.class).child("").exists();
-            } else if (StringUtils.isEmpty(file)) {
+            if (StringUtils.isEmpty(file)) {
                 getContext().get(TaskListener.class).getLogger().println(Messages.FileExistsStep_EmptyString());
+                return getContext().get(FilePath.class).child("").exists();
             }
         	return getContext().get(FilePath.class).child(file).exists();
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/FileExistsStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/FileExistsStep.java
@@ -78,7 +78,10 @@ public final class FileExistsStep extends Step {
         }
 
         @Override protected Boolean run() throws Exception {
-            if (StringUtils.isEmpty(file)) {
+            if (file == null) {
+                getContext().get(TaskListener.class).getLogger().println(Messages.FileExistsStep_NullString());
+                return getContext().get(FilePath.class).child("").exists();
+            } else if (StringUtils.isEmpty(file)) {
                 getContext().get(TaskListener.class).getLogger().println(Messages.FileExistsStep_EmptyString());
             }
         	return getContext().get(FilePath.class).child(file).exists();

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/Messages.properties
@@ -1,4 +1,5 @@
 ArtifactArchiverStepExecution.Deprecated=The archive step is deprecated, please use archiveArtifacts instead.
 ArtifactArchiverStepExecution.NoFiles=No files found to archive for pattern "{0}"; continuing.
 ArtifactArchiverStepExecution.NoFilesWithExcludes=No files found to archive for pattern "{0}", excluding "{1}"; continuing.
-FileExistsStep.EmptyString=The fileExists step was called with the empty string, so the current directory will be checked instead.
+FileExistsStep.EmptyString=The fileExists step was called with an empty string, so the current directory will be checked instead.
+FileExistsStep.NullString=The fileExists step was called with a null string, so the current directory will be checked instead.

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/Messages.properties
@@ -1,5 +1,4 @@
 ArtifactArchiverStepExecution.Deprecated=The archive step is deprecated, please use archiveArtifacts instead.
 ArtifactArchiverStepExecution.NoFiles=No files found to archive for pattern "{0}"; continuing.
 ArtifactArchiverStepExecution.NoFilesWithExcludes=No files found to archive for pattern "{0}", excluding "{1}"; continuing.
-FileExistsStep.EmptyString=The fileExists step was called with an empty string, so the current directory will be checked instead.
-FileExistsStep.NullString=The fileExists step was called with a null string, so the current directory will be checked instead.
+FileExistsStep.EmptyString=The fileExists step was called with a null or empty string, so the current directory will be checked instead.

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/FileExistsStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/FileExistsStepTest.java
@@ -29,4 +29,16 @@ public class FileExistsStepTest {
             }
         });
     }
+
+    @Test
+    public void nullStringWarning() {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition("node { fileExists(null) }", true));
+                story.j.assertLogContains(Messages.FileExistsStep_NullString(), story.j.buildAndAssertSuccess(p));
+            }
+        });
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/FileExistsStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/FileExistsStepTest.java
@@ -37,7 +37,7 @@ public class FileExistsStepTest {
             public void evaluate() throws Throwable {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("node { fileExists(null) }", true));
-                story.j.assertLogContains(Messages.FileExistsStep_NullString(), story.j.buildAndAssertSuccess(p));
+                story.j.assertLogContains(Messages.FileExistsStep_EmptyString(), story.j.buildAndAssertSuccess(p));
             }
         });
     }


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>

fileExists can be called with a null parameter but will throw an NPE. Avoid the NPE by using a blank string instead.