### PR TITLE
Use waitForMessage in tests to reduce flakes

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStepTest.java
@@ -98,7 +98,7 @@ public class WaitForConditionStepTest {
                 // TODO the following fails (missing message) when run as part of whole suite, but not standalone: story.j.assertLogContains(message, story.j.assertBuildStatus(Result.FAILURE, story.j.waitForCompletion(b)));
                 story.j.waitForCompletion(b);
                 story.j.assertBuildStatus(Result.FAILURE, b);
-                story.j.assertLogContains(message, b); // TODO observed to flake on windows-8-2.32.3: see two `semaphore`s and a “Will try again after 0.25 sec” but no such message
+                story.j.waitForMessage(message, b); // TODO observed to flake on windows-8-2.32.3: see two `semaphore`s and a “Will try again after 0.25 sec” but no such message
             }
         });
     }


### PR DESCRIPTION
Hi we're experiencing flakey tests trying to integrate the next bom line,

example:
```
Expected: a string containing "broken condition"
     but: was "Started
Running in Durability level: MAX_SURVIVABILITY
[Pipeline] Start of Pipeline
[Pipeline] waitUntil
[Pipeline] {
[Pipeline] semaphore
[Pipeline] }
Will try again after 0.25 sec
[Pipeline] {
[Pipeline] semaphore
[Pipeline] }
[Pipeline] // waitUntil
[Pipeline] End of Pipeline
```

@jglick suggested replacing assertLogContains with waitForMessage
https://github.com/jenkinsci/bom/pull/110#issuecomment-594782396