### PR TITLE
Improve help text for the sleep and timeout steps

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SleepStep/help-time.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SleepStep/help-time.html
@@ -1,0 +1,3 @@
+<div>
+    The length of time for which the step will sleep.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/SleepStep/help-unit.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/SleepStep/help-unit.html
@@ -1,0 +1,3 @@
+<div>
+    The unit for the time parameter. Defaults to 'SECONDS' if not specified.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help-time.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help-time.html
@@ -1,0 +1,3 @@
+<div>
+    The length of time for which this step will wait before cancelling the nested block.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help-unit.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help-unit.html
@@ -1,0 +1,3 @@
+<div>
+    The unit of the time parameter. Defaults to 'MINUTES' if not specified.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/TimeoutStep/help.html
@@ -1,6 +1,5 @@
 <div>
     Executes the code inside the block with a determined time out limit.
-    If the time limit is reached, an exception (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException) is thrown, which leads in aborting 
+    If the time limit is reached, an exception (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException) is thrown, which leads to aborting
     the build (unless it is caught and processed somehow).
-    Unit is optional but defaults to minutes.
 </div>


### PR DESCRIPTION
Updates the help text for the `sleep` and `timeout` steps, mainly to mention the default unit for the `unit` parameters for each step in dedicated `help-$field.html` files . Subsumes #46 and #14.