### PR TITLE
Add new step 'debug'

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/DebugStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/DebugStep.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2014, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Executes the body if debug is enabled
+ */
+public class DebugStep extends Step {
+
+	private final Boolean isDebugEnabled;
+
+	@DataBoundConstructor
+	public DebugStep(Boolean isDebugEnabled) {
+		if (isDebugEnabled == null) {
+			throw new IllegalArgumentException("A parameter is required to specify if debug is enabled or not");
+		}
+		this.isDebugEnabled = isDebugEnabled;
+	}
+
+	public Boolean getIsDebugEnabled() {
+		return isDebugEnabled;
+	}
+
+	@Override
+	public DescriptorImpl getDescriptor() {
+		return (DescriptorImpl) super.getDescriptor();
+	}
+
+	@Override
+	public StepExecution start(StepContext context) throws Exception {
+		return new DebugStepExecution(isDebugEnabled, context);
+	}
+
+	@Extension
+	public static class DescriptorImpl extends StepDescriptor {
+
+		@Override
+		public String getFunctionName() {
+			return "debug";
+		}
+
+		@Override
+		public boolean takesImplicitBlockArgument() {
+			return true;
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "Executes the body if pipeline is under debug mode";
+		}
+
+		@Override
+		public Set<? extends Class<?>> getRequiredContext() {
+			return Collections.singleton(TaskListener.class);
+		}
+
+	}
+
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/DebugStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/DebugStepExecution.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.plugins.workflow.steps;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+
+public class DebugStepExecution extends StepExecution {
+
+	@SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Only used when starting.")
+	private transient final Boolean isDebugEnabled;
+
+	DebugStepExecution(Boolean isDebugEnabled, StepContext context) {
+		super(context);
+		this.isDebugEnabled = isDebugEnabled;
+	}
+
+	@Override
+	public boolean start() throws Exception {
+		StepContext context = getContext();
+		if (isDebugEnabled) {
+			context.newBodyInvoker().withDisplayName("DEBUG ENABLED").withCallback(BodyExecutionCallback.wrap(context)).start();
+			return false;
+		}
+		getContext().get(TaskListener.class).getLogger().println("(SKIPPED)");
+		context.onSuccess(Result.SUCCESS);
+		return true;
+	}
+
+	@Override
+	public void onResume() {
+	}
+
+	private static final long serialVersionUID = 1L;
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/DebugStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/DebugStep/config.jelly
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2014 Jesse Glick.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="isDebugEnabled" name="isDebugEnabled" title="${%Is debug enabled?}">
+        <select name="isDebugEnabled">
+            <option value="true">YES</option>
+            <option value="false">NO</option>
+        </select>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/DebugStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/DebugStep/help.html
@@ -1,0 +1,3 @@
+<div>
+    Execute the block content if debug mode is enabled (Parameter is TRUE)
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/DebugStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/DebugStepTest.java
@@ -1,0 +1,63 @@
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Tests {@link DebugStep}.
+ */
+public class DebugStepTest {
+
+	@ClassRule
+	public static BuildWatcher buildWatcher = new BuildWatcher();
+	@Rule
+	public JenkinsRule r = new JenkinsRule();
+
+	public static final String DEBUG_BLOCK_EXECUTED = "DEBUG_BLOCK_EXECUTED";
+
+	@Test
+	public void debugEnabledExecuteTheBlock() throws Exception {
+		WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+		p.setDefinition(new CpsFlowDefinition("debug(true) {\n" + "    println '" + DEBUG_BLOCK_EXECUTED + "'\n" + "}\n" + "println 'Done!'", true));
+
+		WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+		r.assertLogContains(DEBUG_BLOCK_EXECUTED, b);
+	}
+
+	@Test
+	public void debugDisabledNotExecuteTheBlock() throws Exception {
+		WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+		p.setDefinition(new CpsFlowDefinition("debug(false) {\n" + "    println '" + DEBUG_BLOCK_EXECUTED + "'\n" + "}\n" + "println 'Done!'", true));
+
+		WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+		r.assertLogNotContains(DEBUG_BLOCK_EXECUTED, b);
+	}
+
+	@Test
+	public void missingParameterBreaksTheBuild() throws Exception {
+		WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+		p.setDefinition(new CpsFlowDefinition("debug {\n" + "    println '" + DEBUG_BLOCK_EXECUTED + "'\n" + "}\n" + "println 'Done!'", true));
+
+		WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+	}
+
+	@Test
+	public void missingBlockBreaksTheBuild() throws Exception {
+		WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+		p.setDefinition(new CpsFlowDefinition("debug(true)\n" + "println 'Done!'", true));
+
+		WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+
+		r.assertLogContains("no body to invoke", b);
+	}
+
+}


### PR DESCRIPTION
Hi,

I'm submitting this PR to create a new simple common step for debug purpose. It will basically only execute the Closure block if the parameter is TRUE.

```
debug(true) {
 < all this block will be executed >
}

debug(false) {
 < all this block will be skipped >
}
```

I think this will improve the readability of the pipelines, cause the developer can use it to make it clear that all that block is intended to output debug data and can be ignored by others just trying to understand the logic executed by the pipeline.

The parameter allows the developer to define when debug mode is enabled or not(for instance, it could be a pipeline parameter).

Signed-off-by: Fernando Cappi <3818944+fcappi@users.noreply.github.com>