### PR TITLE
[JENKINS-29144] Extend CoreStep to also pass EnvVars to SimpleBuildStep

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(useAci: true)
+buildPlugin(useAci: true, configurations: [
+  [ platform: "linux", jdk: "8", ],
+  [ platform: "windows", jdk: "8", ],
+  [ platform: "linux", jdk: "11", jenkins: "2.241" ] // 2.241 includes JENKINS-29144
+])

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.1</version>
+        <version>4.2</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.21</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.241</jenkins.version>
+        <jenkins.version>2.164.3</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.56</version>
+        <version>4.1</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -80,26 +80,6 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.26</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.26</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.26</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-            <version>1.7.26</version>
-        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.21</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.240-rc30032.5a9c198e2a33</jenkins.version>
+        <jenkins.version>2.241</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.21</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.164.3</jenkins.version>
+        <jenkins.version>2.240-rc30032.5a9c198e2a33</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>
@@ -80,6 +80,26 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>1.7.26</version>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.workflow.steps;
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -41,6 +42,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.CheckForNull;
 import jenkins.model.Jenkins;
@@ -75,9 +77,14 @@ public final class CoreStep extends Step {
         }
 
         @Override protected Void run() throws Exception {
-            FilePath workspace = getContext().get(FilePath.class);
+            final StepContext ctx = this.getContext();
+            final FilePath workspace = Objects.requireNonNull(ctx.get(FilePath.class));
             workspace.mkdirs();
-            delegate.perform(getContext().get(Run.class), workspace, getContext().get(Launcher.class), getContext().get(TaskListener.class));
+            final Run<?,?> run = Objects.requireNonNull(ctx.get(Run.class));
+            final EnvVars env = Objects.requireNonNull(ctx.get(EnvVars.class));
+            final Launcher launcher = Objects.requireNonNull(ctx.get(Launcher.class));
+            final TaskListener listener = Objects.requireNonNull(ctx.get(TaskListener.class));
+            delegate.perform(run, workspace, env, launcher, listener);
             return null;
         }
 
@@ -121,7 +128,7 @@ public final class CoreStep extends Step {
         }
 
         @Override public Set<? extends Class<?>> getRequiredContext() {
-            return ImmutableSet.of(Run.class, FilePath.class, Launcher.class, TaskListener.class);
+            return ImmutableSet.of(Run.class, FilePath.class, EnvVars.class, Launcher.class, TaskListener.class);
         }
 
         @Override public String argumentsToString(Map<String, Object> namedArgs) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PwdStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PwdStep.java
@@ -95,7 +95,11 @@ public class PwdStep extends Step {
 
         @Override protected String run() throws Exception {
             FilePath cwd = getContext().get(FilePath.class);
-            return (tmp ? WorkspaceList.tempDir(cwd) : cwd).getRemote();
+            if (tmp && cwd != null)
+                cwd = WorkspaceList.tempDir(cwd);
+            if (cwd == null)
+                return null; // FIXME: Or throw an exception?
+            return cwd.getRemote();
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PwdStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PwdStep.java
@@ -100,8 +100,9 @@ public class PwdStep extends Step {
             Objects.requireNonNull(cwd);
             if (tmp) {
                 cwd = WorkspaceList.tempDir(cwd);
-                if (cwd == null)
+                if (cwd == null) {
                     throw new IOException("Failed to set up a temporary directory.");
+                }
             }
             return cwd.getRemote();
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PwdStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PwdStep.java
@@ -28,8 +28,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.slaves.WorkspaceList;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -95,10 +97,12 @@ public class PwdStep extends Step {
 
         @Override protected String run() throws Exception {
             FilePath cwd = getContext().get(FilePath.class);
-            if (tmp && cwd != null)
+            Objects.requireNonNull(cwd);
+            if (tmp) {
                 cwd = WorkspaceList.tempDir(cwd);
-            if (cwd == null)
-                return null; // FIXME: Or throw an exception?
+                if (cwd == null)
+                    throw new IOException("Failed to set up a temporary directory.");
+            }
             return cwd.getRemote();
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.steps;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
@@ -104,6 +105,7 @@ public final class WriteFileStep extends Step {
             this.step = step;
         }
 
+        @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "https://github.com/spotbugs/spotbugs/issues/756")
         @Override protected Void run() throws Exception {
             FilePath file = getContext().get(FilePath.class).child(step.file);
             if (ReadFileStep.BASE64_ENCODING.equals(step.encoding)) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
@@ -35,6 +35,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -110,6 +111,7 @@ public class CatchErrorStepTest {
         r.assertLogContains("execution continued", b);
     }
 
+    @Ignore("This fails with recent Jenkins versions; not sure if it should still be expected to work.")
     @Test public void optionalMessage() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
@@ -35,7 +35,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -111,7 +110,6 @@ public class CatchErrorStepTest {
         r.assertLogContains("execution continued", b);
     }
 
-    @Ignore("This fails with recent Jenkins versions; not sure if it should still be expected to work.")
     @Test public void optionalMessage() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
@@ -35,16 +35,12 @@ import hudson.tasks.ArtifactArchiver;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.tasks.Fingerprinter;
-import hudson.util.VersionNumber;
 import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.mail.internet.InternetAddress;
-import jenkins.model.Jenkins;
 import jenkins.plugins.mailer.tasks.i18n.Messages;
 import jenkins.tasks.SimpleBuildStep;
-import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
@@ -55,9 +51,7 @@ import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 import org.jenkinsci.plugins.workflow.graphanalysis.NodeStepTypePredicate;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Assert;
 import static org.junit.Assert.*;
-import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -180,7 +174,7 @@ public class CoreStepTest {
         public BuilderWithEnvironment() {
         }
 
-        // Once the plugin depends on Jenkins 2.241 or later, this can be a real @Override
+        // TODO: Once the plugin depends on Jenkins 2.241 or later, this can be a real @Override
         //@Override
         public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             assertNull(env.get("BUILD_ID"));
@@ -189,7 +183,7 @@ public class CoreStepTest {
 
         @Override
         public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
-            Assert.fail("This method should not get called.");
+            fail("This method should not get called.");
         }
 
         @Symbol("buildWithEnvironment")
@@ -205,8 +199,6 @@ public class CoreStepTest {
     @Issue("JENKINS-29144")
     @Test
     public void builderWithEnvironment() throws Exception {
-        Assume.assumeTrue("Requires API added in Jenkins 2.241.",
-                Objects.requireNonNull(Jenkins.getVersion()).isNewerThanOrEqualTo(new VersionNumber("2.241")));
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node { withEnv(['TICKET=JENKINS-29144', 'BUILD_ID=']) { buildWithEnvironment() } }", true));
         r.buildAndAssertSuccess(p);

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
@@ -195,14 +195,11 @@ public class CoreStepTest {
         @Symbol("buildWithEnvironment")
         @TestExtension("builderWithEnvironment")
         public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
-
             @Override
             public boolean isApplicable(Class<? extends AbstractProject> jobType) {
                 return true;
             }
-
         }
-
     }
 
     @Issue("JENKINS-29144")

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
@@ -193,11 +193,12 @@ public class CoreStepTest {
 
     }
 
+    @Issue("JENKINS-29144")
     @Test
     public void builderWithEnvironment() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node { withEnv(['TICKET=JENKINS-29144', 'BUILD_ID=']) { buildWithEnvironment() } }", true));
-        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.buildAndAssertSuccess(p);
     }
 
 }


### PR DESCRIPTION
Subsumes #116. See [JENKINS-29144](https://issues.jenkins-ci.org/browse/JENKINS-29144).

This PR adds some minor formatting changes, updates the Jenkinsfile to test against 2.241 as well as the current baseline, and changes `CoreStep` from using the Jenkins version to decide whether to call the new overload of `perform` to directly check for the new method instead.