### PR TITLE
[JENKINS-46175] Make workspace context optional for CoreStep and CoreWrapperStep.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.56</version>
+        <version>4.2</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.21</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.164.3</jenkins.version>
+        <jenkins.version>2.245-SNAPSHOT</jenkins.version> <!-- https://github.com/jenkinsci/jenkins/pull/4829 -->
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.21</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.245-SNAPSHOT</jenkins.version> <!-- https://github.com/jenkinsci/jenkins/pull/4829 -->
+        <jenkins.version>2.245-rc30110.cfe16f60d3ee</jenkins.version> <!-- https://github.com/jenkinsci/jenkins/pull/4829 -->
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.21</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.250-rc30297.9ba996d437dd</jenkins.version> <!-- https://github.com/jenkinsci/jenkins/pull/4829 -->
+        <jenkins.version>2.164.3</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-basic-steps</artifactId>
-    <version>2.20</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Basic Steps</name>
     <url>https://github.com/jenkinsci/workflow-basic-steps-plugin</url>
@@ -47,7 +47,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>workflow-basic-steps-2.20</tag>
+        <tag>${scmTag}</tag>
     </scm>
     <repositories>
         <repository>
@@ -62,7 +62,7 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <revision>2.20</revision>
+        <revision>2.21</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.164.3</jenkins.version>
         <java.level>8</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.21</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.245-rc30110.cfe16f60d3ee</jenkins.version> <!-- https://github.com/jenkinsci/jenkins/pull/4829 -->
+        <jenkins.version>2.250-rc30297.9ba996d437dd</jenkins.version> <!-- https://github.com/jenkinsci/jenkins/pull/4829 -->
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
@@ -86,11 +86,11 @@ public final class CoreStep extends Step {
             final TaskListener listener = Objects.requireNonNull(ctx.get(TaskListener.class));
             final EnvVars env = Objects.requireNonNull(ctx.get(EnvVars.class));
             boolean workspaceRequired = true;
-            // In Jenkins 2.25x, a SimpleBuildStep can indicate that it does not require a workspace context by
+            // In Jenkins 2.258, a SimpleBuildStep can indicate that it does not require a workspace context by
             // overriding a requiresWorkspace() method to return false. So use that if it's available.
             // Note: this uses getMethod() on the delegate's type and not SimpleBuildStep so that an implementation can
-            // get this behaviour without switching to Jenkins 2.25x itself.
-            // TODO: Use 'workspaceRequired = this.delegate.requiresWorkspace()' once this plugin depends on Jenkins 2.25x or later.
+            // get this behaviour without switching to Jenkins 2.258 itself.
+            // TODO: Use 'workspaceRequired = this.delegate.requiresWorkspace()' once this plugin depends on Jenkins 2.258 or later.
             try {
                 final Method requiresWorkspace = this.delegate.getClass().getMethod("requiresWorkspace");
                 workspaceRequired = (boolean) requiresWorkspace.invoke(this.delegate);
@@ -116,10 +116,10 @@ public final class CoreStep extends Step {
                 delegate.perform(run, workspace, env, launcher, listener);
             } else {
                 // If we get here, workspaceRequired is false and there is no workspace context. In that case, the
-                // overload of perform() introduced in Jenkins 2.25x MUST exist.
+                // overload of perform() introduced in Jenkins 2.258 MUST exist.
                 // Note: this uses getMethod() on the delegate's type and not SimpleBuildStep so that an implementation
-                // can get this behaviour without switching to Jenkins 2.25x itself.
-                // TODO: Use 'this.delegate.perform(run, env, listener)' once the minimum core version for this plugin is 2.25x or newer.
+                // can get this behaviour without switching to Jenkins 2.258 itself.
+                // TODO: Use 'this.delegate.perform(run, env, listener)' once the minimum core version for this plugin is 2.258 or newer.
                 final Method perform = this.delegate.getClass().getMethod("perform", Run.class, EnvVars.class, TaskListener.class);
                 try {
                     perform.invoke(this.delegate, run, env, listener);

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
@@ -92,8 +92,7 @@ public class CoreWrapperStep extends Step {
         }
 
         private void doStart() throws Exception {
-            SimpleBuildWrapper.Context c = new SimpleBuildWrapper.Context();
-            c.setWorkspaceRequirement(this.delegate);
+            SimpleBuildWrapper.Context c = this.delegate.createContext();
             final StepContext context = getContext();
             final Run<?, ?> run = context.get(Run.class);
             assert run != null;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
@@ -95,9 +95,9 @@ public class CoreWrapperStep extends Step {
 
         private void doStart() throws Exception {
             SimpleBuildWrapper.Context c = null;
-            // In Jenkins 2.25x, a createContext() method on SimpleBuildWrapper is required to ensure that a Disposer
+            // In Jenkins 2.258, a createContext() method on SimpleBuildWrapper is required to ensure that a Disposer
             // registered on that context inherits the wrapper's workspace requirement. Use it when available.
-            // TODO: Use 'c = this.delegate.createContext()' once this plugin depends on Jenkins 2.25x or later.
+            // TODO: Use 'c = this.delegate.createContext()' once this plugin depends on Jenkins 2.258 or later.
             try {
                 final Method createContext = SimpleBuildWrapper.class.getMethod("createContext");
                 c = (SimpleBuildWrapper.Context) createContext.invoke(this.delegate);
@@ -119,11 +119,11 @@ public class CoreWrapperStep extends Step {
                 final FilePath workspace = context.get(FilePath.class);
                 final Launcher launcher = context.get(Launcher.class);
                 boolean workspaceRequired = true;
-                // In Jenkins 2.25x, a SimpleBuildWrapper can indicate that it does not require a workspace context by
+                // In Jenkins 2.258, a SimpleBuildWrapper can indicate that it does not require a workspace context by
                 // overriding a requiresWorkspace() method to return false. So use that if it's available.
                 // Note: this uses getMethod() on the delegate's type and not SimpleBuildWrapper so that an
-                // implementation can get this behaviour without switching to Jenkins 2.25x itself.
-                // TODO: Use 'workspaceRequired = this.delegate.requiresWorkspace()' once this plugin depends on Jenkins 2.25x or later.
+                // implementation can get this behaviour without switching to Jenkins 2.258 itself.
+                // TODO: Use 'workspaceRequired = this.delegate.requiresWorkspace()' once this plugin depends on Jenkins 2.258 or later.
                 try {
                     final Method requiresWorkspace = this.delegate.getClass().getMethod("requiresWorkspace");
                     workspaceRequired = (boolean) requiresWorkspace.invoke(this.delegate);
@@ -146,10 +146,10 @@ public class CoreWrapperStep extends Step {
                     this.delegate.setUp(c, run, workspace, launcher, listener, env);
                 } else {
                     // If we get here, workspaceRequired is false and there is no workspace context. In that case, the
-                    // overload of setUp() introduced in Jenkins 2.25x MUST exist.
+                    // overload of setUp() introduced in Jenkins 2.258 MUST exist.
                     // Note: this uses getMethod() on the delegate's type and not SimpleBuildWrapper so that an
-                    // implementation can get this behaviour without switching to Jenkins 2.25x itself.
-                    // TODO: Use 'this.delegate.setUp(c, run, listener, env)' once the minimum core version for this plugin is 2.25x or newer.
+                    // implementation can get this behaviour without switching to Jenkins 2.258 itself.
+                    // TODO: Use 'this.delegate.setUp(c, run, listener, env)' once the minimum core version for this plugin is 2.258 or newer.
                     final Method perform = this.delegate.getClass().getMethod("setUp", SimpleBuildWrapper.Context.class, Run.class, TaskListener.class, EnvVars.class);
                     try {
                         perform.invoke(this.delegate, c, run, listener, env);
@@ -220,12 +220,12 @@ public class CoreWrapperStep extends Step {
             final FilePath workspace = context.get(FilePath.class);
             final Launcher launcher = context.get(Launcher.class);
             boolean workspaceRequired = true;
-            // In Jenkins 2.25x, a Disposer has a final requiresWorkspace() method that indicates whether or not it (or
+            // In Jenkins 2.258, a Disposer has a final requiresWorkspace() method that indicates whether or not it (or
             // more accurately, its associated wrapper) requires a workspace context. This is set up via the Context, as
             // long as that is created via SimpleBuildWrapper.createContext().
             // Note: this uses getMethod() on the disposer's type and not SimpleBuildWrapper.Disposer so that an
-            // implementation can get this behaviour without switching to Jenkins 2.25x itself.
-            // TODO: Use 'workspaceRequired = this.disposer.requiresWorkspace()' once this plugin depends on Jenkins 2.25x or later.
+            // implementation can get this behaviour without switching to Jenkins 2.258 itself.
+            // TODO: Use 'workspaceRequired = this.disposer.requiresWorkspace()' once this plugin depends on Jenkins 2.258 or later.
             try {
                 final Method requiresWorkspace = this.disposer.getClass().getMethod("requiresWorkspace");
                 workspaceRequired = (boolean) requiresWorkspace.invoke(this.disposer);
@@ -248,10 +248,10 @@ public class CoreWrapperStep extends Step {
                 this.disposer.tearDown(run, workspace, launcher, listener);
             } else {
                 // If we get here, workspaceRequired is false and there is no workspace context. In that case, the
-                // overload of tearDown() introduced in Jenkins 2.25x MUST exist.
+                // overload of tearDown() introduced in Jenkins 2.258 MUST exist.
                 // Note: this uses getMethod() on the disposer's type and not SimpleBuildWrapper.Disposer so that an
-                // implementation can get this behaviour without switching to Jenkins 2.25x itself.
-                // TODO: Use 'this.disposer.tearDown(run, listener)' once the minimum core version for this plugin is 2.25x or newer.
+                // implementation can get this behaviour without switching to Jenkins 2.258 itself.
+                // TODO: Use 'this.disposer.tearDown(run, listener)' once the minimum core version for this plugin is 2.258 or newer.
                 final Method perform = this.disposer.getClass().getMethod("tearDown", Run.class, TaskListener.class);
                 try {
                     perform.invoke(this.disposer, run, listener);

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
@@ -207,15 +207,15 @@ public class CoreStepTest {
         @DataBoundConstructor
         public BuilderWithWorkspaceRequirement() {
         }
-        // TODO: Remove once the minimum core version for this plugin is 2.25x or newer.
+        // TODO: Remove once the minimum core version for this plugin is 2.258 or newer.
         public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             fail("This method should not get called.");
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
         public void perform(@Nonnull Run<?, ?> run, @Nonnull EnvVars env, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context required, but not provided!");
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
         public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context required and provided.");
         }
@@ -247,19 +247,19 @@ public class CoreStepTest {
         @DataBoundConstructor
         public BuilderWithoutWorkspaceRequirement() {
         }
-        // TODO: Remove once the minimum core version for this plugin is 2.25x or newer.
+        // TODO: Remove once the minimum core version for this plugin is 2.258 or newer.
         public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             fail("This method should not get called.");
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
         public void perform(@Nonnull Run<?, ?> run, @Nonnull EnvVars env, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context not needed.");
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
         public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context not needed, but provided.");
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
         public boolean requiresWorkspace() {
             return false;
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
@@ -208,11 +208,15 @@ public class CoreStepTest {
         @DataBoundConstructor
         public BuilderWithWorkspaceRequirement() {
         }
-        @Override
+        // TODO: Remove once the minimum core version for this plugin is 2.25x or newer.
+        public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+            fail("This method should not get called.");
+        }
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
         public void perform(@Nonnull Run<?, ?> run, @Nonnull EnvVars env, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context required, but not provided!");
         }
-        @Override
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
         public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context required and provided.");
         }
@@ -244,15 +248,19 @@ public class CoreStepTest {
         @DataBoundConstructor
         public BuilderWithoutWorkspaceRequirement() {
         }
-        @Override
+        // TODO: Remove once the minimum core version for this plugin is 2.25x or newer.
+        public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+            fail("This method should not get called.");
+        }
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
         public void perform(@Nonnull Run<?, ?> run, @Nonnull EnvVars env, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context not needed.");
         }
-        @Override
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
         public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context not needed, but provided.");
         }
-        @Override
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
         public boolean requiresWorkspace() {
             return false;
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
@@ -293,7 +293,7 @@ public class CoreWrapperStepTest {
             listener.getLogger().println(">>> workspace context required and provided.");
             context.setDisposer(new DisposerWithWorkspaceRequirement());
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
         public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
             listener.getLogger().println(">>> workspace context required but not provided!");
             context.setDisposer(new DisposerWithWorkspaceRequirement());
@@ -302,7 +302,7 @@ public class CoreWrapperStepTest {
             @Override public void tearDown(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context required and provided.");
             }
-            // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+            // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
             public void tearDown(@Nonnull Run<?, ?> build, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context required but not provided!");
             }
@@ -339,24 +339,24 @@ public class CoreWrapperStepTest {
 
     public static final class WrapperWithoutWorkspaceRequirement extends SimpleBuildWrapper {
         @DataBoundConstructor public WrapperWithoutWorkspaceRequirement() { }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
         public boolean requiresWorkspace() { return false; }
         @Override public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
             listener.getLogger().println(">>> workspace context not needed, but provided.");
             context.setDisposer(new DisposerWithoutWorkspaceRequirement());
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
         public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
             listener.getLogger().println(">>> workspace context not needed.");
             context.setDisposer(new DisposerWithoutWorkspaceRequirement());
         }
         public static final class DisposerWithoutWorkspaceRequirement extends Disposer {
-            // TODO: Remove once the minimum core version for this plugin is 2.25x or newer.
+            // TODO: Remove once the minimum core version for this plugin is 2.258 or newer.
             public boolean requiresWorkspace() { return false; }
             @Override public void tearDown(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context not needed, but provided.");
             }
-            // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+            // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
             public void tearDown(@Nonnull Run<?, ?> build, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context not needed.");
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.workflow.steps;
 
 import com.google.common.base.Predicates;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Functions;
@@ -290,19 +289,21 @@ public class CoreWrapperStepTest {
 
     public static final class WrapperWithWorkspaceRequirement extends SimpleBuildWrapper {
         @DataBoundConstructor public WrapperWithWorkspaceRequirement() { }
-        @Override public void setUp(@NonNull Context context, @NonNull Run<?, ?> build, @NonNull FilePath workspace, @NonNull Launcher launcher, @NonNull TaskListener listener, @NonNull EnvVars initialEnvironment) throws IOException, InterruptedException {
+        @Override public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
             listener.getLogger().println(">>> workspace context required and provided.");
             context.setDisposer(new DisposerWithWorkspaceRequirement());
         }
-        @Override public void setUp(@NonNull Context context, @NonNull Run<?, ?> build, @NonNull TaskListener listener, @NonNull EnvVars initialEnvironment) throws IOException, InterruptedException {
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+        public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
             listener.getLogger().println(">>> workspace context required but not provided!");
             context.setDisposer(new DisposerWithWorkspaceRequirement());
         }
         public static final class DisposerWithWorkspaceRequirement extends Disposer {
-            @Override public void tearDown(@NonNull Run<?, ?> build, @NonNull FilePath workspace, @NonNull Launcher launcher, @NonNull TaskListener listener) throws IOException, InterruptedException {
+            @Override public void tearDown(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context required and provided.");
             }
-            @Override public void tearDown(@NonNull Run<?, ?> build, @NonNull TaskListener listener) throws IOException, InterruptedException {
+            // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+            public void tearDown(@Nonnull Run<?, ?> build, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context required but not provided!");
             }
         }
@@ -338,20 +339,25 @@ public class CoreWrapperStepTest {
 
     public static final class WrapperWithoutWorkspaceRequirement extends SimpleBuildWrapper {
         @DataBoundConstructor public WrapperWithoutWorkspaceRequirement() { }
-        @Override public void setUp(@NonNull Context context, @NonNull Run<?, ?> build, @NonNull FilePath workspace, @NonNull Launcher launcher, @NonNull TaskListener listener, @NonNull EnvVars initialEnvironment) throws IOException, InterruptedException {
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+        public boolean requiresWorkspace() { return false; }
+        @Override public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
             listener.getLogger().println(">>> workspace context not needed, but provided.");
             context.setDisposer(new DisposerWithoutWorkspaceRequirement());
         }
-        @Override public void setUp(@NonNull Context context, @NonNull Run<?, ?> build, @NonNull TaskListener listener, @NonNull EnvVars initialEnvironment) throws IOException, InterruptedException {
+        // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+        public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
             listener.getLogger().println(">>> workspace context not needed.");
             context.setDisposer(new DisposerWithoutWorkspaceRequirement());
         }
-        @Override public boolean requiresWorkspace() { return false; }
         public static final class DisposerWithoutWorkspaceRequirement extends Disposer {
-            @Override public void tearDown(@NonNull Run<?, ?> build, @NonNull FilePath workspace, @NonNull Launcher launcher, @NonNull TaskListener listener) throws IOException, InterruptedException {
+            // TODO: Remove once the minimum core version for this plugin is 2.25x or newer.
+            public boolean requiresWorkspace() { return false; }
+            @Override public void tearDown(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context not needed, but provided.");
             }
-            @Override public void tearDown(@NonNull Run<?, ?> build, @NonNull TaskListener listener) throws IOException, InterruptedException {
+            // TODO: Mark as @Override once the minimum core version for this plugin is 2.25x or newer.
+            public void tearDown(@Nonnull Run<?, ?> build, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context not needed.");
             }
         }


### PR DESCRIPTION
This is a variation of https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/117, using the API changes from https://github.com/jenkinsci/jenkins/pull/4829.

Also contains the `PwdStep` fix from https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/122.

Marking as draft because there are multiple variations, both here and at the core level.