### PR TITLE
Do not use ACI agents on ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(useAci: true)
+buildPlugin()


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/123, https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/122, and https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/121 (in an earlier build) have all had issues on the Windows branch because of errors like this:

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.2.0:jar (attach-javadocs) on project workflow-basic-steps: MavenReportException: Error while generating Javadoc: Unable to find javadoc command: The environment variable JAVA_HOME is not correctly set. 

I asked about it in #jenkins-infra and it seems like there were some issues provisioning Windows agents, so someone added the `maven-windows` label to agents that don't normally have it, so maybe that was the issue? Let's see if non-ACI agents have the same problem. I also issued a rebuild of #122 and #121 to see if ACI agents have been fixed in the meantime.

The [docs for `buildPlugin`](https://github.com/jenkins-infra/pipeline-library#optional-arguments) make me think that `useAci` should not affect Windows agents, but [the code](https://github.com/jenkins-infra/pipeline-library/blob/3382e5e4279a50ac8e3e169dcb862efcbadefd20/vars/buildPlugin.groovy#L43-L49) makes me think otherwise, not sure if that is a bug or I am missing something.