### PR TITLE
Remove CatchErrorStepTest.optionalMessage because it is invalid

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
@@ -110,16 +110,6 @@ public class CatchErrorStepTest {
         r.assertLogContains("execution continued", b);
     }
 
-    @Test public void optionalMessage() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition(
-                "catchError('caught error') {\n" +
-                "  error 'oops'\n" +
-                "}", true));
-        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
-        assertCatchError(r, b, Result.FAILURE, null, true);
-    }
-
     @Test public void customBuildResult() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(


### PR DESCRIPTION
This test is invalid and should not have been added in https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/83, see https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/116#discussion_r436741358. Essentially, the test was passing, but for the wrong reason. The expectation was that the step would run and "caught error" would be printed to the logs, but what was actually happening was that the step could not be instantiated because the `message` parameter is optional and so must be specified like this: `message: 'blah'`, but the test was passing because "caught error" showed up in the exception thrown when the step could not be instantiated. 