### PR TITLE
[JENKINS-29144] Require Jenkins 2.249.1 or newer to avoid reflection

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(useAci: true, configurations: [
   [ platform: "linux", jdk: "8", ],
   [ platform: "windows", jdk: "8", ],
-  [ platform: "linux", jdk: "11", jenkins: "2.241" ] // 2.241 includes JENKINS-29144
+  [ platform: "linux", jdk: "11" ]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.2</version>
+        <version>4.7</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.22</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.164.3</jenkins.version>
+        <jenkins.version>2.249.1</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>
@@ -72,8 +72,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.164.x</artifactId>
-                <version>9</version>
+                <artifactId>bom-2.249.x</artifactId>
+                <version>12</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
@@ -37,7 +37,6 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -84,15 +83,8 @@ public final class CoreStep extends Step {
             final Run<?,?> run = Objects.requireNonNull(ctx.get(Run.class));
             final Launcher launcher = Objects.requireNonNull(ctx.get(Launcher.class));
             final TaskListener listener = Objects.requireNonNull(ctx.get(TaskListener.class));
-            // TODO: Replace with a direct call to SimpleBuildStep.perform(Run, FilePath, EnvVars, Launcher, TaskListener) once the minimum core version for this plugin is 2.241 or newer.
-            try {
-                final Method perform = this.delegate.getClass().getMethod("perform", Run.class, FilePath.class,
-                        EnvVars.class, Launcher.class, TaskListener.class);
-                final EnvVars env = Objects.requireNonNull(ctx.get(EnvVars.class));
-                perform.invoke(this.delegate, run, workspace, env, launcher, listener);
-            } catch(NoSuchMethodException e) {
-                this.delegate.perform(run, workspace, launcher, listener);
-            }
+            final EnvVars env = Objects.requireNonNull(ctx.get(EnvVars.class));
+            delegate.perform(run, workspace, env, launcher, listener);
             return null;
         }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
@@ -174,8 +174,7 @@ public class CoreStepTest {
         public BuilderWithEnvironment() {
         }
 
-        // TODO: Once the plugin depends on Jenkins 2.241 or later, this can be a real @Override
-        //@Override
+        @Override
         public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             assertNull(env.get("BUILD_ID"));
             assertEquals("JENKINS-29144", env.get("TICKET"));


### PR DESCRIPTION
Same as #127 but also updates the Jenkinsfile to stop building against 2.241.