### PR TITLE
Disposer.requiresWorkspace is final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.7</version>
+        <version>4.12</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.23</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.249.1</jenkins.version>
+        <jenkins.version>2.263</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>
@@ -72,7 +72,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.249.x</artifactId>
+                <artifactId>bom-2.249.x</artifactId> <!-- TODO https://github.com/jenkinsci/bom/pull/339 -->
                 <version>12</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java
@@ -37,8 +37,6 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -85,22 +83,7 @@ public final class CoreStep extends Step {
             final Launcher launcher = ctx.get(Launcher.class);
             final TaskListener listener = Objects.requireNonNull(ctx.get(TaskListener.class));
             final EnvVars env = Objects.requireNonNull(ctx.get(EnvVars.class));
-            boolean workspaceRequired = true;
-            // In Jenkins 2.258, a SimpleBuildStep can indicate that it does not require a workspace context by
-            // overriding a requiresWorkspace() method to return false. So use that if it's available.
-            // Note: this uses getMethod() on the delegate's type and not SimpleBuildStep so that an implementation can
-            // get this behaviour without switching to Jenkins 2.258 itself.
-            // TODO: Use 'workspaceRequired = this.delegate.requiresWorkspace()' once this plugin depends on Jenkins 2.258 or later.
-            try {
-                final Method requiresWorkspace = this.delegate.getClass().getMethod("requiresWorkspace");
-                workspaceRequired = (boolean) requiresWorkspace.invoke(this.delegate);
-            } catch(NoSuchMethodException e) {
-                // ok, default to true
-            } catch (InvocationTargetException ite) {
-                final Throwable realException = ite.getCause();
-                throw realException instanceof Exception ? (Exception) realException : ite;
-            }
-            if (workspaceRequired) {
+            if (delegate.requiresWorkspace()) {
                 if (workspace == null) {
                     throw new MissingContextVariableException(FilePath.class);
                 }
@@ -115,18 +98,7 @@ public final class CoreStep extends Step {
             if (workspace != null && launcher != null) {
                 delegate.perform(run, workspace, env, launcher, listener);
             } else {
-                // If we get here, workspaceRequired is false and there is no workspace context. In that case, the
-                // overload of perform() introduced in Jenkins 2.258 MUST exist.
-                // Note: this uses getMethod() on the delegate's type and not SimpleBuildStep so that an implementation
-                // can get this behaviour without switching to Jenkins 2.258 itself.
-                // TODO: Use 'this.delegate.perform(run, env, listener)' once the minimum core version for this plugin is 2.258 or newer.
-                final Method perform = this.delegate.getClass().getMethod("perform", Run.class, EnvVars.class, TaskListener.class);
-                try {
-                    perform.invoke(this.delegate, run, env, listener);
-                } catch (InvocationTargetException ite) {
-                    final Throwable realException = ite.getCause();
-                    throw realException instanceof Exception ? (Exception) realException : ite;
-                }
+                delegate.perform(run, env, listener);
             }
             return null;
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStep.java
@@ -115,8 +115,6 @@ public class CoreWrapperStep extends Step {
                 if (workspace != null && launcher != null) {
                     this.delegate.setUp(c, run, workspace, launcher, listener, env);
                 } else {
-                    // If we get here, workspaceRequired is false and there is no workspace context. In that case, the
-                    // overload of setUp() introduced in Jenkins 2.258 MUST exist.
                     delegate.setUp(c, run, listener, env);
                 }
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreStepTest.java
@@ -207,16 +207,10 @@ public class CoreStepTest {
         @DataBoundConstructor
         public BuilderWithWorkspaceRequirement() {
         }
-        // TODO: Remove once the minimum core version for this plugin is 2.258 or newer.
-        public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
-            fail("This method should not get called.");
-        }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
-        public void perform(@Nonnull Run<?, ?> run, @Nonnull EnvVars env, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+        @Override public void perform(@Nonnull Run<?, ?> run, @Nonnull EnvVars env, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context required, but not provided!");
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
-        public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+        @Override public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context required and provided.");
         }
         // While the @TextExtension supposedly limits this descriptor to the named test method, it still gets picked up
@@ -247,20 +241,13 @@ public class CoreStepTest {
         @DataBoundConstructor
         public BuilderWithoutWorkspaceRequirement() {
         }
-        // TODO: Remove once the minimum core version for this plugin is 2.258 or newer.
-        public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
-            fail("This method should not get called.");
-        }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
-        public void perform(@Nonnull Run<?, ?> run, @Nonnull EnvVars env, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+        @Override public void perform(@Nonnull Run<?, ?> run, @Nonnull EnvVars env, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context not needed.");
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
-        public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+        @Override public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull EnvVars env, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
             listener.getLogger().println("workspace context not needed, but provided.");
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
-        public boolean requiresWorkspace() {
+        @Override public boolean requiresWorkspace() {
             return false;
         }
         // While the @TextExtension supposedly limits this descriptor to the named test method, it still gets picked up

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
@@ -351,8 +351,6 @@ public class CoreWrapperStepTest {
             context.setDisposer(new DisposerWithoutWorkspaceRequirement());
         }
         public static final class DisposerWithoutWorkspaceRequirement extends Disposer {
-            // TODO: Remove once the minimum core version for this plugin is 2.258 or newer.
-            public boolean requiresWorkspace() { return false; }
             @Override public void tearDown(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context not needed, but provided.");
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CoreWrapperStepTest.java
@@ -293,8 +293,7 @@ public class CoreWrapperStepTest {
             listener.getLogger().println(">>> workspace context required and provided.");
             context.setDisposer(new DisposerWithWorkspaceRequirement());
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
-        public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
+        @Override public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
             listener.getLogger().println(">>> workspace context required but not provided!");
             context.setDisposer(new DisposerWithWorkspaceRequirement());
         }
@@ -302,8 +301,7 @@ public class CoreWrapperStepTest {
             @Override public void tearDown(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context required and provided.");
             }
-            // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
-            public void tearDown(@Nonnull Run<?, ?> build, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+            @Override public void tearDown(@Nonnull Run<?, ?> build, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context required but not provided!");
             }
         }
@@ -339,14 +337,12 @@ public class CoreWrapperStepTest {
 
     public static final class WrapperWithoutWorkspaceRequirement extends SimpleBuildWrapper {
         @DataBoundConstructor public WrapperWithoutWorkspaceRequirement() { }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
-        public boolean requiresWorkspace() { return false; }
+        @Override public boolean requiresWorkspace() { return false; }
         @Override public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
             listener.getLogger().println(">>> workspace context not needed, but provided.");
             context.setDisposer(new DisposerWithoutWorkspaceRequirement());
         }
-        // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
-        public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
+        @Override public void setUp(@Nonnull Context context, @Nonnull Run<?, ?> build, @Nonnull TaskListener listener, @Nonnull EnvVars initialEnvironment) throws IOException, InterruptedException {
             listener.getLogger().println(">>> workspace context not needed.");
             context.setDisposer(new DisposerWithoutWorkspaceRequirement());
         }
@@ -354,8 +350,7 @@ public class CoreWrapperStepTest {
             @Override public void tearDown(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context not needed, but provided.");
             }
-            // TODO: Mark as @Override once the minimum core version for this plugin is 2.258 or newer.
-            public void tearDown(@Nonnull Run<?, ?> build, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+            @Override public void tearDown(@Nonnull Run<?, ?> build, @Nonnull TaskListener listener) throws IOException, InterruptedException {
                 listener.getLogger().println("<<< workspace context not needed.");
             }
         }


### PR DESCRIPTION
#123 mistakenly kept an override of `Disposer.requiresWorkspace`, which in the ultimate version of the API was not necessary (this method need only be overridden in `SimpleBuildWrapper`), and is in fact `final`. Because of reflection, this mistake was not noticed until PCT uncovered it in https://github.com/jenkinsci/bom/pull/339.
