### PR TITLE
Reduce flakiness of windows timeout test

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
@@ -262,7 +262,7 @@ public class TimeoutStepTest {
                      "node('!master') {\n" +
                      "  timeout(time:5, unit:'SECONDS', activity: true) {\n" +
                     (Functions.isWindows() ?
-                     "   bat '@echo off & echo NotHere && ping -n 3 127.0.0.1 >NUL && echo NotHereYet && ping -n 3 127.0.0.1 >NUL && echo JustHere && ping -n 10 127.0.0.1 >NUL && echo ShouldNot'\n" :
+                     "   bat '@echo off & echo NotHere && ping -n 3 127.0.0.1 >NUL && echo NotHereYet && ping -n 3 127.0.0.1 >NUL && echo JustHere && ping -n 20 127.0.0.1 >NUL && echo ShouldNot'\n" :
                      "   sh 'set +x; echo NotHere; sleep 3; echo NotHereYet; sleep 3; echo JustHere; sleep 10; echo ShouldNot'\n" ) +
                      "  }\n" +
                      "}\n", true));


### PR DESCRIPTION
Increase the time sleep before the next print.
This should never fail as it likely will be force killed after 5 seconds.

See https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/132#issuecomment-723038487