### PR TITLE
Corrected flakes in StashTest

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashTest.java
@@ -73,7 +73,9 @@ public class StashTest {
         SemaphoreStep.success("ending/1", null);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("got fname: whatever other: more", b);
-        assertEquals("{}", StashManager.stashesOf(b).toString()); // TODO flake expected:<{[]}> but was:<{[from-top={elsewhere/fname=whatever}, whatever={fname=whatever, other=more}]}>
+        while (!StashManager.stashesOf(b).isEmpty()) {
+            Thread.sleep(100);
+        }
     }
 
     @Issue("JENKINS-31086")

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/stash/StashTest.java
@@ -116,7 +116,9 @@ public class StashTest {
         SemaphoreStep.success("ending/1", null);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         r.assertLogContains("Stashed 0 file(s)", b);
-        assertEquals("{}", StashManager.stashesOf(b).toString());
+        while (!StashManager.stashesOf(b).isEmpty()) {
+            Thread.sleep(100);
+        }
         List<FlowNode> coreStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("stash"));
         assertThat(coreStepNodes, Matchers.hasSize(1));
         assertEquals("whatever", ArgumentsAction.getStepArgumentsAsString(coreStepNodes.get(0)));


### PR DESCRIPTION
Seen for example in https://github.com/jenkinsci/bom/pull/357. As can be seen in https://github.com/jenkinsci/workflow-job-plugin/blob/32090697af62e9513de78dd1ed096a6bace8651e/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java#L639-L643 the build is marked completed just before stashes are cleared.
