### PR TITLE
chore: Document that `retry` does not catch inner timeout

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/RetryStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/RetryStep/help.html
@@ -1,5 +1,5 @@
 <div>
     Retry the block (up to N times) if any exception happens during its body execution.
     If an exception happens on the final attempt then it will lead to aborting the build (unless it is caught and processed somehow).
-    User aborts of the build are <em>not</em> caught.
+    Please note that timeouts and user aborts of the build are <em>not</em> caught by a retry block.
 </div>


### PR DESCRIPTION
As per https://issues.jenkins.io/browse/JENKINS-51454?focusedCommentId=381283&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-381283

this PR modifies the documentation for the `retry` block to mention that

```groovy
retry(3) {
    timeout(XXX) {
    // steps
    }
}
```

does not behave as expected.

Ref. https://github.com/jenkins-infra/docker-jenkins-weekly/pull/205 where we tried it, but we discovered that it never retries when the timeout is reached.

This commit can be safely reverted when #81 would be merged.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~[ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~
