### PR TITLE
Migrate from `RestartableJenkinsRule` to `JenkinsSessionRule`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/EnvStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/EnvStepTest.java
@@ -46,17 +46,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 public class EnvStepTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
-    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    @Rule public JenkinsSessionRule sessions = new JenkinsSessionRule();
 
-    @Test public void overriding() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void overriding() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                     "env.CUSTOM = 'initial'\n" +
                     "env.FOOPATH = node {isUnix() ? '/opt/foos' : 'C:\\\\foos'}\n" +
@@ -68,10 +68,10 @@ public class EnvStepTest {
                     "  }\n" +
                     "  isUnix() ? sh('echo outside CUSTOM=$CUSTOM NOVEL=$NOVEL NULLED=outside') : bat('echo outside CUSTOM=%CUSTOM% NOVEL=%NOVEL% NULLED=outside')\n" +
                     "}", true));
-                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                story.j.assertLogContains(Functions.isWindows() ? "inside CUSTOM=override NOVEL=val BUILD_TAG=custom NULLED= FOOPATH=C:\\ball;C:\\foos;" : "inside CUSTOM=override NOVEL=val BUILD_TAG=custom NULLED= FOOPATH=/opt/ball:/opt/foos:", b);
-                story.j.assertLogContains("groovy NULLED=null", b);
-                story.j.assertLogContains("outside CUSTOM=initial NOVEL= NULLED=outside", b);
+                WorkflowRun b = j.buildAndAssertSuccess(p);
+                j.assertLogContains(Functions.isWindows() ? "inside CUSTOM=override NOVEL=val BUILD_TAG=custom NULLED= FOOPATH=C:\\ball;C:\\foos;" : "inside CUSTOM=override NOVEL=val BUILD_TAG=custom NULLED= FOOPATH=/opt/ball:/opt/foos:", b);
+                j.assertLogContains("groovy NULLED=null", b);
+                j.assertLogContains("outside CUSTOM=initial NOVEL= NULLED=outside", b);
                 List<FlowNode> coreStepNodes = new DepthFirstScanner().filteredNodes(
                         b.getExecution(),
                         Predicates.and(
@@ -79,14 +79,12 @@ public class EnvStepTest {
                                 n -> n instanceof StepStartNode && !((StepStartNode) n).isBody()));
                 assertThat(coreStepNodes, Matchers.hasSize(1));
                 assertEquals("CUSTOM, NOVEL, BUILD_TAG, NULLED, FOOPATH+BALL", ArgumentsAction.getStepArgumentsAsString(coreStepNodes.get(0)));
-            }
         });
     }
 
-    @Test public void parallel() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void parallel() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                     "parallel a: {\n" +
                     "  node {withEnv(['TOOL=aloc']) {semaphore 'a'; isUnix() ? sh('echo a TOOL=$TOOL') : bat('echo a TOOL=%TOOL%')}}\n" +
@@ -98,17 +96,15 @@ public class EnvStepTest {
                 SemaphoreStep.waitForStart("b/1", b);
                 SemaphoreStep.success("a/1", null);
                 SemaphoreStep.success("b/1", null);
-                story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b));
-                story.j.assertLogContains("a TOOL=aloc", b);
-                story.j.assertLogContains("b TOOL=bloc", b);
-            }
+                j.assertBuildStatusSuccess(j.waitForCompletion(b));
+                j.assertLogContains("a TOOL=aloc", b);
+                j.assertLogContains("b TOOL=bloc", b);
         });
     }
 
-    @Test public void restarting() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void restarting() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                     "def show(which) {\n" +
                     "  echo \"groovy ${which} ${env.TESTVAR}:\"\n" +
@@ -124,26 +120,22 @@ public class EnvStepTest {
                     "}", true));
                 WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();
                 SemaphoreStep.waitForStart("restarting/1", b);
-            }
         });
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
+        sessions.then(j -> {
                 SemaphoreStep.success("restarting/1", null);
-                WorkflowRun b = story.j.assertBuildStatusSuccess(story.j.waitForCompletion(story.j.jenkins.getItemByFullName("p", WorkflowJob.class).getLastBuild()));
-                story.j.assertLogContains("groovy before val:", b);
-                story.j.assertLogContains("shell before val:", b);
-                story.j.assertLogContains("groovy after val:", b);
-                story.j.assertLogContains("shell after val:", b);
-                story.j.assertLogContains("groovy outside null:", b);
-                story.j.assertLogContains("shell outside :", b);
-            }
+                WorkflowRun b = j.assertBuildStatusSuccess(j.waitForCompletion(j.jenkins.getItemByFullName("p", WorkflowJob.class).getLastBuild()));
+                j.assertLogContains("groovy before val:", b);
+                j.assertLogContains("shell before val:", b);
+                j.assertLogContains("groovy after val:", b);
+                j.assertLogContains("shell after val:", b);
+                j.assertLogContains("groovy outside null:", b);
+                j.assertLogContains("shell outside :", b);
         });
     }
 
-    @Test public void nested() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void nested() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
                     "  withEnv(['A=one']) {\n" +
@@ -152,23 +144,21 @@ public class EnvStepTest {
                     "    }\n" +
                     "  }\n" +
                     "}", true));
-                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                story.j.assertLogContains("A=one B=two", b);
-            }
+                WorkflowRun b = j.buildAndAssertSuccess(p);
+                j.assertLogContains("A=one B=two", b);
         });
     }
 
-    @Test public void configRoundTrip() throws Exception {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                configRoundTrip(Collections.emptyList());
-                configRoundTrip(Collections.singletonList("VAR1=val1"));
-                configRoundTrip(Arrays.asList("VAR1=val1", "VAR2=val2"));
-            }
-            private void configRoundTrip(List<String> overrides) throws Exception {
-                assertEquals(overrides, new StepConfigTester(story.j).configRoundTrip(new EnvStep(overrides)).getOverrides());
-            }
+    @Test public void configRoundTrip() throws Throwable {
+        sessions.then(j -> {
+                configRoundTrip(Collections.emptyList(), j);
+                configRoundTrip(Collections.singletonList("VAR1=val1"), j);
+                configRoundTrip(Arrays.asList("VAR1=val1", "VAR2=val2"), j);
         });
+    }
+
+    private static void configRoundTrip(List<String> overrides, JenkinsRule j) throws Exception {
+        assertEquals(overrides, new StepConfigTester(j).configRoundTrip(new EnvStep(overrides)).getOverrides());
     }
 
     // TODO add @LocalData serialForm test proving compatibility with executions dating back to workflow 1.4.3 on 1.580.1

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/FileExistsStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/FileExistsStepTest.java
@@ -8,37 +8,31 @@ import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 public class FileExistsStepTest {
 
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule
-    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    public JenkinsSessionRule sessions = new JenkinsSessionRule();
 
     @Issue("JENKINS-48138")
     @Test
-    public void emptyStringWarning() {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    public void emptyStringWarning() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("node { fileExists('') }", true));
-                story.j.assertLogContains(Messages.FileExistsStep_EmptyString(), story.j.buildAndAssertSuccess(p));
-            }
+                j.assertLogContains(Messages.FileExistsStep_EmptyString(), j.buildAndAssertSuccess(p));
         });
     }
 
     @Test
-    public void nullStringWarning() {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    public void nullStringWarning() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("node { fileExists(null) }", true));
-                story.j.assertLogContains(Messages.FileExistsStep_EmptyString(), story.j.buildAndAssertSuccess(p));
-            }
+                j.assertLogContains(Messages.FileExistsStep_EmptyString(), j.buildAndAssertSuccess(p));
         });
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/SleepStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/SleepStepTest.java
@@ -39,17 +39,16 @@ import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 public class SleepStepTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
-    @Rule public RestartableJenkinsRule r = new RestartableJenkinsRule();
+    @Rule public JenkinsSessionRule sessions = new JenkinsSessionRule();
 
-    @Test public void sleepAndRestart() {
-        r.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = r.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void sleepAndRestart() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("semaphore 'start'; sleep 10", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("start/1", b);
@@ -57,27 +56,21 @@ public class SleepStepTest {
                 ((CpsFlowExecution) b.getExecution()).waitForSuspension();
                 List<FlowNode> heads = b.getExecution().getCurrentHeads();
                 assertEquals(1, heads.size());
-                assertEquals(r.j.jenkins.getDescriptorByType(SleepStep.DescriptorImpl.class), ((StepAtomNode) heads.get(0)).getDescriptor());
-            }
+                assertEquals(j.jenkins.getDescriptorByType(SleepStep.DescriptorImpl.class), ((StepAtomNode) heads.get(0)).getDescriptor());
         });
-        r.addStep(new Statement() {
-            @SuppressWarnings("SleepWhileInLoop")
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = r.j.jenkins.getItemByFullName("p", WorkflowJob.class);
+        sessions.then(j -> {
+                WorkflowJob p = j.jenkins.getItemByFullName("p", WorkflowJob.class);
                 WorkflowRun b = p.getLastBuild();
-                r.j.assertBuildStatusSuccess(r.j.waitForCompletion(b));
-            }
+                j.assertBuildStatusSuccess(j.waitForCompletion(b));
         });
     }
 
     @Issue("JENKINS-31701")
-    @Test public void sleepInsideNode() {
-        r.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = r.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void sleepInsideNode() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("node {sleep 1}", true));
-                r.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-            }
+                j.buildAndAssertSuccess(p);
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepTest.java
@@ -59,7 +59,7 @@ import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.recipes.LocalData;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -68,18 +68,16 @@ public class TimeoutStepTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
 
-    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    @Rule public JenkinsSessionRule sessions = new JenkinsSessionRule();
 
     @Rule public GitSampleRepoRule git = new GitSampleRepoRule();
 
-    @Test public void configRoundTrip() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
+    @Test public void configRoundTrip() throws Throwable {
+        sessions.then(j -> {
                 TimeoutStep s1 = new TimeoutStep(3);
                 s1.setUnit(TimeUnit.HOURS);
-                TimeoutStep s2 = new StepConfigTester(story.j).configRoundTrip(s1);
-                story.j.assertEqualDataBoundBeans(s1, s2);
-            }
+                TimeoutStep s2 = new StepConfigTester(j).configRoundTrip(s1);
+                j.assertEqualDataBoundBeans(s1, s2);
         });
     }
 
@@ -87,40 +85,32 @@ public class TimeoutStepTest {
      * The simplest possible timeout step ever.
      */
     @Test
-    public void basic() throws Exception {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    public void basic() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                         "node { timeout(time:5, unit:'SECONDS') { sleep 10; echo 'NotHere' } }", true));
-                WorkflowRun b = story.j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0).get());
-                story.j.assertLogNotContains("NotHere", b);
-            }
+                WorkflowRun b = j.buildAndAssertStatus(Result.ABORTED, p);
+                j.assertLogNotContains("NotHere", b);
         });
     }
 
     @Issue("JENKINS-34637")
     @Test
-    public void basicWithBlock() {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    public void basicWithBlock() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                         "node { timeout(time:5, unit:'SECONDS') { withEnv([]) { sleep 7; echo 'NotHere' } } }", true));
-                WorkflowRun b = story.j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0).get());
-                story.j.assertLogNotContains("NotHere", b);
-            }
+                WorkflowRun b = j.buildAndAssertStatus(Result.ABORTED, p);
+                j.assertLogNotContains("NotHere", b);
         });
     }
 
     @Test
-    public void killingParallel() throws Exception {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    public void killingParallel() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  timeout(time:5, unit:'SECONDS') {\n"
@@ -132,12 +122,12 @@ public class TimeoutStepTest {
                         + "  }\n"
                         + "  echo 'NotHere'\n"
                         + "}\n", true));
-                WorkflowRun b = story.j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0).get());
+                WorkflowRun b = j.buildAndAssertStatus(Result.ABORTED, p);
 
                 // make sure things that are supposed to run do, and things that are NOT supposed to run do not.
-                story.j.assertLogNotContains("NotHere", b);
-                story.j.assertLogContains("ShouldBeHere1", b);
-                story.j.assertLogContains("ShouldBeHere2", b);
+                j.assertLogNotContains("NotHere", b);
+                j.assertLogContains("ShouldBeHere1", b);
+                j.assertLogContains("ShouldBeHere2", b);
 
                 // we expect every sleep step to have failed
                 FlowGraphTable t = new FlowGraphTable(b.getExecution());
@@ -150,17 +140,14 @@ public class TimeoutStepTest {
                         }
                     }
                 }
-            }
         });
     }
 
     @Issue("JENKINS-26521")
     @Test
-    public void activity() throws Exception {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    public void activity() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  timeout(time:5, unit:'SECONDS', activity: true) {\n"
@@ -173,20 +160,17 @@ public class TimeoutStepTest {
                         + "    echo 'ShouldNot!';\n"
                         + "  }\n"
                         + "}\n", true));
-                WorkflowRun b = story.j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0).get());
-                story.j.assertLogContains("JustHere!", b);
-                story.j.assertLogNotContains("ShouldNot!", b);
-            }
+                WorkflowRun b = j.buildAndAssertStatus(Result.ABORTED, p);
+                j.assertLogContains("JustHere!", b);
+                j.assertLogNotContains("ShouldNot!", b);
         });
     }
 
     @Issue("JENKINS-26521")
     @Test
-    public void activityInParallel() throws Exception {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    public void activityInParallel() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  parallel(\n"
@@ -208,20 +192,17 @@ public class TimeoutStepTest {
                         + "      }\n"
                         + "    })\n"
                         + "}\n", true));
-                WorkflowRun b = story.j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0).get());
-                story.j.assertLogContains("JustHere!", b);
-                story.j.assertLogNotContains("ShouldNot!", b);
-            }
+                WorkflowRun b = j.buildAndAssertStatus(Result.ABORTED, p);
+                j.assertLogContains("JustHere!", b);
+                j.assertLogNotContains("ShouldNot!", b);
         });
     }
 
     @Issue("JENKINS-26521")
     @Test
-    public void activityRestart() throws Exception {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "restarted");
+    public void activityRestart() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "restarted");
                 p.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  timeout(time:15, unit:'SECONDS', activity: true) {\n"
@@ -238,27 +219,23 @@ public class TimeoutStepTest {
                         + "}\n", true));
                 WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();
                 SemaphoreStep.waitForStart("restarted/1", b);
-            }
         });
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.getItemByFullName("restarted", WorkflowJob.class);
+        sessions.then(j -> {
+                WorkflowJob p = j.jenkins.getItemByFullName("restarted", WorkflowJob.class);
                 WorkflowRun b = p.getBuildByNumber(1);
                 assertTrue("took more than 15s to restart?", b.isBuilding());
                 SemaphoreStep.success("restarted/1", null);
-                story.j.assertBuildStatus(Result.ABORTED, story.j.waitForCompletion(b));
-                story.j.assertLogContains("JustHere!", b);
-                story.j.assertLogNotContains("ShouldNot!", b);
-            }
+                j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b));
+                j.assertLogContains("JustHere!", b);
+                j.assertLogNotContains("ShouldNot!", b);
         });
     }
 
     @Test
-    public void activityRemote() {
-        story.then(r -> {
-            r.createSlave();
-            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+    public void activityRemote() throws Throwable {
+        sessions.then(j -> {
+            j.createSlave();
+            WorkflowJob p = j.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition("" +
                      "node('!master') {\n" +
                      "  timeout(time:5, unit:'SECONDS', activity: true) {\n" +
@@ -267,37 +244,35 @@ public class TimeoutStepTest {
                      "   sh 'set +x; echo NotHere; sleep 3; echo NotHereYet; sleep 3; echo JustHere; sleep 10; echo ShouldNot'\n" ) +
                      "  }\n" +
                      "}\n", true));
-            WorkflowRun b = r.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0));
-            story.j.assertLogContains("JustHere", b);
-            story.j.assertLogNotContains("ShouldNot", b);
+            WorkflowRun b = j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0));
+            j.assertLogContains("JustHere", b);
+            j.assertLogNotContains("ShouldNot", b);
         });
     }
 
     @Issue("JENKINS-54078")
-    @Test public void activityGit() {
-        story.then(r -> {
-            r.createSlave();
+    @Test public void activityGit() throws Throwable {
+        sessions.then(j -> {
+            j.createSlave();
             git.init();
             git.write("file", "content");
             git.git("commit", "--all", "--message=init");
-            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            WorkflowJob p = j.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition("" +
                      "node('!master') {\n" +
                      "  timeout(time: 5, unit: 'MINUTES', activity: true) {\n" +
                      "    git($/" + git + "/$)\n" +
                      "  }\n" +
                      "}\n", true));
-            r.buildAndAssertSuccess(p);
+            j.buildAndAssertSuccess(p);
         });
     }
 
     @Issue("JENKINS-26163")
     @Test
-    public void restarted() throws Exception {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "restarted");
+    public void restarted() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "restarted");
                 p.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  timeout(time: 15, unit: 'SECONDS') {\n"
@@ -307,26 +282,20 @@ public class TimeoutStepTest {
                         + "}\n", true));
                 WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();
                 SemaphoreStep.waitForStart("restarted/1", b);
-            }
         });
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.getItemByFullName("restarted", WorkflowJob.class);
+        sessions.then(j -> {
+                WorkflowJob p = j.jenkins.getItemByFullName("restarted", WorkflowJob.class);
                 WorkflowRun b = p.getBuildByNumber(1);
                 assertTrue("took more than 15s to restart?", b.isBuilding());
                 SemaphoreStep.success("restarted/1", null);
-                story.j.assertBuildStatus(Result.ABORTED, story.j.waitForCompletion(b));
-            }
+                j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b));
         });
     }
 
     @Test
-    public void timeIsConsumed() throws Exception {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "timeIsConsumed");
+    public void timeIsConsumed() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "timeIsConsumed");
                 p.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  timeout(time: 20, unit: 'SECONDS') {\n"
@@ -337,33 +306,27 @@ public class TimeoutStepTest {
                         + "}\n", true));
                 WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();
                 SemaphoreStep.waitForStart("timeIsConsumed/1", b);
-            }
         });
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.getItemByFullName("timeIsConsumed", WorkflowJob.class);
+        sessions.then(j -> {
+                WorkflowJob p = j.jenkins.getItemByFullName("timeIsConsumed", WorkflowJob.class);
                 WorkflowRun b = p.getBuildByNumber(1);
                 SemaphoreStep.success("timeIsConsumed/1", null);
-                WorkflowRun run = story.j.waitForCompletion(b);
+                WorkflowRun run = j.waitForCompletion(b);
                 InterruptedBuildAction action = b.getAction(InterruptedBuildAction.class);
                 assumeThat("TODO sometimes flakes", action, notNullValue());
                 List<CauseOfInterruption> causes = action.getCauses();
                 assertEquals(1, causes.size());
                 assertEquals(TimeoutStepExecution.ExceededTimeout.class, causes.get(0).getClass());
-                story.j.assertBuildStatus(Result.ABORTED, run);
-            }
+                j.assertBuildStatus(Result.ABORTED, run);
         });
     }
 
     @Issue("JENKINS-39072")
-    @Test public void unresponsiveBody() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void unresponsiveBody() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("timeout(time: 2, unit: 'SECONDS') {unkillable()}", true));
-                story.j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0).get());
-            }
+                j.buildAndAssertStatus(Result.ABORTED, p);
         });
     }
     public static class UnkillableStep extends Step {
@@ -394,13 +357,11 @@ public class TimeoutStepTest {
 
     @Ignore("TODO cannot find any way to solve this case")
     @Issue("JENKINS-39072")
-    @Test public void veryUnresponsiveBody() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void veryUnresponsiveBody() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("timeout(time: 2, unit: 'SECONDS') {while (true) {try {sleep 10} catch (e) {echo(/ignoring ${e}/)}}}", true));
-                story.j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0).get());
-            }
+                j.buildAndAssertStatus(Result.ABORTED, p);
         });
     }
 
@@ -408,57 +369,53 @@ public class TimeoutStepTest {
 
     @Issue("JENKINS-39134")
     @LocalData
-    @Test public void serialForm() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.getItemByFullName("timeout", WorkflowJob.class);
+    @Test public void serialForm() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.jenkins.getItemByFullName("timeout", WorkflowJob.class);
                 WorkflowRun b = p.getBuildByNumber(1);
                 RunListener.fireStarted(b, TaskListener.NULL);
-                story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b));
-            }
+                j.assertBuildStatusSuccess(j.waitForCompletion(b));
         });
     }
 
     @Issue("JENKINS-54607")
-    @Test public void gracePeriod() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void gracePeriod() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("timeout(time: 15, unit: 'SECONDS') {unkillable()}", true));
-                story.j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0).get());
+                j.buildAndAssertStatus(Result.ABORTED, p);
                 assertThat(p.getLastBuild().getDuration(), lessThan(29_000L)); // 29 seconds
-            }
         });
     }
 
     @Issue("JENKINS-42940")
     @LocalData
-    @Test public void noImmediateForcibleTerminationOnResume() throws Exception {
+    @Test public void noImmediateForcibleTerminationOnResume() throws Throwable {
         /* Source of the @LocalData for reference:
-        story.then(r -> {
-            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        sessions.then(j -> {
+            WorkflowJob p = j.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                     "timeout(time: 1, unit: 'SECONDS') {\n" +
                     "  unkillable()\n" +
                     "}\n", true));
             WorkflowRun b = p.scheduleBuild2(0).waitForStart();
-            r.waitForMessage("ignoring " + FlowInterruptedException.class.getName(), b);
+            j.waitForMessage("ignoring " + FlowInterruptedException.class.getName(), b);
             // Saved while TimeoutStepExecution.forcible was true, between the first cancel and the force cancel.
             // Required some poking around in internals to save TimeoutStepExecution in the right state, which is why
             // this test uses @LocalData instead of just running the build directly.
         });*/
-        story.then(r -> {
-            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+        sessions.then(j -> {
+            WorkflowJob p = j.jenkins.getItemByFullName("p", WorkflowJob.class);
             WorkflowRun b = p.getBuildByNumber(1);
-            r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
+            j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b));
         });
     }
 
     @Test
-    public void nestingDetection() {
-        story.then(r -> {
+    public void nestingDetection() throws Throwable {
+        sessions.then(j -> {
             ScriptApproval.get().approveSignature("method org.jenkinsci.plugins.workflow.steps.FlowInterruptedException isActualInterruption");
-            WorkflowJob p = story.j.createProject(WorkflowJob.class);
+            WorkflowJob p = j.createProject(WorkflowJob.class);
 
             // Inside
             p.setDefinition(
@@ -471,9 +428,9 @@ public class TimeoutStepTest {
                                     + "  }\n"
                                     + "}",
                             true));
-            WorkflowRun b = story.j.buildAndAssertSuccess(p);
-            story.j.assertLogContains("GOOD", b);
-            story.j.assertLogNotContains("BAD", b);
+            WorkflowRun b = j.buildAndAssertSuccess(p);
+            j.assertLogContains("GOOD", b);
+            j.assertLogNotContains("BAD", b);
 
             // Outside
             p.setDefinition(
@@ -486,9 +443,9 @@ public class TimeoutStepTest {
                                     + "  echo e.isActualInterruption() ? 'BAD' : 'GOOD'\n"
                                     + "}",
                             true));
-            b = story.j.buildAndAssertSuccess(p);
-            story.j.assertLogContains("GOOD", b);
-            story.j.assertLogNotContains("BAD", b);
+            b = j.buildAndAssertSuccess(p);
+            j.assertLogContains("GOOD", b);
+            j.assertLogNotContains("BAD", b);
 
             // Between
             p.setDefinition(
@@ -503,9 +460,9 @@ public class TimeoutStepTest {
                                     + "  }\n"
                                     + "}",
                             true));
-            b = story.j.buildAndAssertSuccess(p);
-            story.j.assertLogContains("GOOD", b);
-            story.j.assertLogNotContains("BAD", b);
+            b = j.buildAndAssertSuccess(p);
+            j.assertLogContains("GOOD", b);
+            j.assertLogNotContains("BAD", b);
 
             // Inside (unkillable)
             p.setDefinition(
@@ -519,8 +476,8 @@ public class TimeoutStepTest {
                                     + "}",
                             true));
             b = p.scheduleBuild2(0).get();
-            story.j.assertLogContains("GOOD", b);
-            story.j.assertLogNotContains("BAD", b);
+            j.assertLogContains("GOOD", b);
+            j.assertLogNotContains("BAD", b);
 
             // Outside (unkillable)
             p.setDefinition(
@@ -533,9 +490,9 @@ public class TimeoutStepTest {
                                     + "  echo e.isActualInterruption() ? 'BAD' : 'GOOD'"
                                     + "}",
                             true));
-            b = story.j.buildAndAssertSuccess(p);
-            story.j.assertLogContains("GOOD", b);
-            story.j.assertLogNotContains("BAD", b);
+            b = j.buildAndAssertSuccess(p);
+            j.assertLogContains("GOOD", b);
+            j.assertLogNotContains("BAD", b);
 
             // Between (unkillable)
             p.setDefinition(
@@ -550,9 +507,9 @@ public class TimeoutStepTest {
                                     + "  }\n"
                                     + "}",
                             true));
-            b = story.j.buildAndAssertSuccess(p);
-            story.j.assertLogContains("GOOD", b);
-            story.j.assertLogNotContains("BAD", b);
+            b = j.buildAndAssertSuccess(p);
+            j.assertLogContains("GOOD", b);
+            j.assertLogNotContains("BAD", b);
         });
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStepTest.java
@@ -39,17 +39,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 public class WaitForConditionStepTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
-    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    @Rule public JenkinsSessionRule sessions = new JenkinsSessionRule();
 
-    @Test public void simple() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void simple() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("waitUntil {semaphore 'wait'}; semaphore 'waited'", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait/1", b);
@@ -60,15 +59,13 @@ public class WaitForConditionStepTest {
                 SemaphoreStep.success("wait/3", true);
                 SemaphoreStep.waitForStart("waited/1", b);
                 SemaphoreStep.success("waited/1", null);
-                story.j.assertLogContains("Will try again after " + Util.getTimeSpanString(WaitForConditionStep.MIN_RECURRENCE_PERIOD), story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
-            }
+                j.assertLogContains("Will try again after " + Util.getTimeSpanString(WaitForConditionStep.MIN_RECURRENCE_PERIOD), j.assertBuildStatusSuccess(j.waitForCompletion(b)));
         });
     }
 
-    @Test public void initialRecurrence() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void initialRecurrence() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("waitUntil(initialRecurrencePeriod: 999) {semaphore 'wait'}; semaphore 'waited'", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait/1", b);
@@ -79,15 +76,13 @@ public class WaitForConditionStepTest {
                 SemaphoreStep.success("wait/3", true);
                 SemaphoreStep.waitForStart("waited/1", b);
                 SemaphoreStep.success("waited/1", null);
-                story.j.assertLogContains("Will try again after " + Util.getTimeSpanString(999), story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
-            }
+                j.assertLogContains("Will try again after " + Util.getTimeSpanString(999), j.assertBuildStatusSuccess(j.waitForCompletion(b)));
         });
     }
 
-    @Test public void failure() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void failure() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("waitUntil {semaphore 'wait'}", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait/1", b);
@@ -95,18 +90,16 @@ public class WaitForConditionStepTest {
                 SemaphoreStep.waitForStart("wait/2", b);
                 String message = "broken condition";
                 SemaphoreStep.failure("wait/2", new AbortException(message));
-                // TODO the following fails (missing message) when run as part of whole suite, but not standalone: story.j.assertLogContains(message, story.j.assertBuildStatus(Result.FAILURE, story.j.waitForCompletion(b)));
-                story.j.waitForCompletion(b);
-                story.j.assertBuildStatus(Result.FAILURE, b);
-                story.j.waitForMessage(message, b); // TODO observed to flake on windows-8-2.32.3: see two `semaphore`s and a “Will try again after 0.25 sec” but no such message
-            }
+                // TODO the following fails (missing message) when run as part of whole suite, but not standalone: j.assertLogContains(message, j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(b)));
+                j.waitForCompletion(b);
+                j.assertBuildStatus(Result.FAILURE, b);
+                j.waitForMessage(message, b); // TODO observed to flake on windows-8-2.32.3: see two `semaphore`s and a “Will try again after 0.25 sec” but no such message
         });
     }
 
-    @Test public void catchErrors() throws Exception {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void catchErrors() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
                     "  waitUntil {\n" +
@@ -124,40 +117,33 @@ public class WaitForConditionStepTest {
                     "echo 'finished waiting'", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait/1", b);
-                story.j.jenkins.getWorkspaceFor(p).child("flag").write("", null);
+                j.jenkins.getWorkspaceFor(p).child("flag").write("", null);
                 SemaphoreStep.success("wait/1", null);
-                story.j.assertLogContains("finished waiting", story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
-            }
+                j.assertLogContains("finished waiting", j.assertBuildStatusSuccess(j.waitForCompletion(b)));
         });
     }
 
-    @Test public void restartDuringBody() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void restartDuringBody() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("waitUntil {semaphore 'wait'}; echo 'finished waiting'", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait/1", b);
                 SemaphoreStep.success("wait/1", false);
                 SemaphoreStep.waitForStart("wait/2", b);
-            }
         });
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowRun b = story.j.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1);
+        sessions.then(j -> {
+                WorkflowRun b = j.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1);
                 SemaphoreStep.success("wait/2", false);
                 SemaphoreStep.waitForStart("wait/3", b);
                 SemaphoreStep.success("wait/3", true);
-                story.j.assertLogContains("finished waiting", story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
-            }
+                j.assertLogContains("finished waiting", j.assertBuildStatusSuccess(j.waitForCompletion(b)));
         });
     }
 
-    @Test public void restartDuringDelay() {
-        story.addStep(new Statement() {
-            @SuppressWarnings("SleepWhileInLoop")
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void restartDuringDelay() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("waitUntil {semaphore 'wait'}; echo 'finished waiting'", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait/1", b);
@@ -175,34 +161,29 @@ public class WaitForConditionStepTest {
                 while (executions.get(0).recurrencePeriod == LONG_TIME) {
                     Thread.sleep(100);
                 }
-                story.j.waitForMessage("Will try again after " + Util.getTimeSpanString(LONG_TIME), b);
+                j.waitForMessage("Will try again after " + Util.getTimeSpanString(LONG_TIME), b);
                 // timer is now waiting for a long time
-            }
         });
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowRun b = story.j.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1);
+        sessions.then(j -> {
+                WorkflowRun b = j.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1);
                 SemaphoreStep.waitForStart("wait/3", b); // TODO pending https://github.com/jenkinsci/workflow-cps-plugin/pull/141 this will flake out
                 SemaphoreStep.success("wait/3", false);
                 SemaphoreStep.waitForStart("wait/4", b);
                 SemaphoreStep.success("wait/4", true);
-                story.j.assertLogContains("finished waiting", story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
-            }
+                j.assertLogContains("finished waiting", j.assertBuildStatusSuccess(j.waitForCompletion(b)));
         });
     }
 
-    @Test public void quiet() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void quiet() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("waitUntil(quiet: true) {semaphore 'wait'}; semaphore 'waited'", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait/1", b);
                 SemaphoreStep.success("wait/1", true);
                 SemaphoreStep.waitForStart("waited/1", b);
                 SemaphoreStep.success("waited/1", null);
-                story.j.assertLogNotContains("Will try again after " + Util.getTimeSpanString(WaitForConditionStep.MIN_RECURRENCE_PERIOD), story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
-            }
+                j.assertLogNotContains("Will try again after " + Util.getTimeSpanString(WaitForConditionStep.MIN_RECURRENCE_PERIOD), j.assertBuildStatusSuccess(j.waitForCompletion(b)));
         });
     }
 


### PR DESCRIPTION
We seem to be generally preferring `JenkinsSessionRule` to `RestartableJenkinsRule`. The main benefit to `JenkinsSessionRule` is that `#then` runs immediately, so it plays nicely with things like `@After.`