### PR TITLE
Make `workflow-basic-steps` compatible with Guava 21.0 and newer

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/TimeoutStepExecution.java
@@ -17,9 +17,12 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -188,7 +191,7 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
                             LOGGER.log(Level.WARNING, null, x);
                         }
                     }
-                }, MoreExecutors.sameThreadExecutor());
+                }, newExecutorService());
             }
         } else {
             listener().getLogger().println("Cancelling nested steps due to timeout");
@@ -196,6 +199,30 @@ public class TimeoutStepExecution extends AbstractStepExecutionImpl {
             forcible = true;
             timeout = GRACE_PERIOD;
             resetTimer();
+        }
+    }
+
+    /**
+     * Returns an {@link ExecutorService} to be used as a parameter in other methods. It calls
+     * {@code MoreExecutors#newDirectExecutorService} or falls back to {@code
+     * MoreExecutors#sameThreadExecutor} for compatibility with older (&lt; 18.0) versions of Guava.
+     *
+     * @since TODO
+     */
+    private static ExecutorService newExecutorService() {
+        try {
+            try {
+                // Guava older than 18
+                Method method = MoreExecutors.class.getMethod("sameThreadExecutor");
+                return (ExecutorService) method.invoke(null);
+            } catch (NoSuchMethodException e) {
+                // TODO Invert this to prefer the newer Guava method once Guava is upgraded in
+                // Jenkins core.
+                Method method = MoreExecutors.class.getMethod("newDirectExecutorService");
+                return (ExecutorService) method.invoke(null);
+            }
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Discovered in jenkinsci/bom#423. Like jenkinsci/workflow-support-plugin#114 and jenkinsci/git-client-plugin#686, but for `workflow-basic-steps`.

`workflow-basic-steps` previously used `MoreExecutors#sameThreadExecutor` from Guava, which was removed in version 21.0 in favor of `MoreExecutors#newDirectExecutorService`. This PR uses reflection to first try to call `MoreExecutors#newDirectExecutorService` but then call `MoreExecutors#sameThreadExecutor` if the first method is not available to support both older and newer versions of Guava.