### PR TITLE
doc [fileExists step] specify that absolute and Windows paths are allowed + add examples

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/FileExistsStep/help-file.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/FileExistsStep/help-file.html
@@ -1,3 +1,28 @@
 <div>
-    Relative (<code>/</code>-separated) path to file within a workspace to verify its existence.
+    Path to a file or a directory to verify its existence.
+    <ul>
+        <li>Both absolute and relative paths are supported. When using relative path, it is relative to the current working directory (by default: the workspace).</li>
+        <li>Both Unix and Windows path are supported using a <pre>/</pre> separator:
+<p><pre>
+node('Linux') {
+    if (fileExists('/usr/local/bin/jenkins.sh') {
+        sh '/usr/local/bin/jenkins.sh'
+    }
+}
+node('Windows') {
+    if (fileExists('C:/jenkins.exe') {
+        bat 'C:/jenkins.exe'
+    }
+}
+</pre></p>
+    When using a Windows path with the anti-slash (<pre>\</pre>) separator, do not forget to escape it:
+<p></pre>
+node('Windows') {
+    if (fileExists('src\\main\\resources') {
+        echo 'Found a directory resources.'
+    }
+}
+</pre></p>
+        </li>
+    </ul>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/FileExistsStep/help-file.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/FileExistsStep/help-file.html
@@ -15,7 +15,7 @@ node('Windows') {
     }
 }
 </pre></p>
-    When using a Windows path with the anti-slash (<pre>\</pre>) separator, do not forget to escape it:
+    When using a Windows path with the backslash (<pre>\</pre>) separator, do not forget to escape it:
 <p></pre>
 node('Windows') {
     if (fileExists('src\\main\\resources') {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/FileExistsStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/FileExistsStep/help.html
@@ -1,4 +1,30 @@
 <div>
-    Checks if the given file (as relative path to current directory) exists.
+    Checks if the given file exists on the current node.
     Returns <code>true | false</code>.
+
+    This step must be run inside a `node` context:
+<p><pre>
+# Declarative Syntax
+stage ('Check for existence of index.html') {
+    agent any # Could be a top-level directive or a stage level directive
+    steps {
+        script {
+            if (fileExists('src/main/rersources/index.html') {
+                echo "File src/main/rersources/index.html found!"
+            }
+        }
+    }
+}
+</pre></p>
+
+With the Declarative Syntax, it must be run in a stage with a defined agent (e.g. different than `agent none`):
+
+<p><pre>
+# Scripted Syntax
+node {
+    if (fileExists('src/main/rersources/index.html') {
+        echo "File src/main/rersources/index.html found!"
+    }
+}
+</pre></p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/FileExistsStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/FileExistsStep/help.html
@@ -2,7 +2,7 @@
     Checks if the given file exists on the current node.
     Returns <code>true | false</code>.
 
-    This step must be run inside a `node` context:
+    This step must be run inside a <code>node</code> context:
 <p><pre>
 # Declarative Syntax
 stage ('Check for existence of index.html') {


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/pipeline-library/pull/232#pullrequestreview-776290117, I stumbled on the current documentation of the `fileExists` step.

This PR aims at adding examples and specifying a bit more what this step can do.