### PR TITLE
Document pwd(tmp:true) is for the current dir

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/PwdStep/help-tmp.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/PwdStep/help-tmp.html
@@ -1,5 +1,6 @@
 <div>
-    If selected, return a temporary directory associated with the workspace rather than the workspace itself.
+    If selected, return a temporary directory associated with the current directory path rather than the directory path itself.
+    The return value is different for each current directory. No two directories share the same temporary directory.
     This is an appropriate place to put temporary files which should not clutter a source checkout;
     local repositories or caches; etc.
 </div>


### PR DESCRIPTION
The pwd(tmp:true) does not return tmp directory for the workspace, but the return value is different for each current directory. The description was misleading suggesting it is associated with the workspace.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
