### PR TITLE
Bump `mock-javamail` from 1.9 to 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,17 +154,22 @@
             <artifactId>matrix-project</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
+            This must come before javax-mail-api in the class path in order to avoid eclipse-ee4j/mail#350.
+        -->
         <dependency>
             <groupId>org.jvnet.mock-javamail</groupId>
             <artifactId>mock-javamail</artifactId>
-            <version>1.9</version>
+            <version>1.12</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.mail</groupId>
-                    <artifactId>mail</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <!--
+            This must come after mock-javamail in the class path in order to avoid eclipse-ee4j/mail#350.
+        -->
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>javax-mail-api</artifactId>
+            <version>1.6.2-5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
See [the release notes](https://github.com/jenkinsci/lib-mock-javamail/releases/tag/mock-javamail-1.12).