### PR TITLE
Remove "Checks if running on a Unix-like node"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/IsUnixStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/IsUnixStep.java
@@ -61,9 +61,6 @@ public class IsUnixStep extends Step {
             return "isUnix";
         }
 
-        @Override public String getDisplayName() {
-            return "Checks if running on a Unix-like node";
-        }
 
         @Override public Set<? extends Class<?>> getRequiredContext() {
             return Collections.singleton(Launcher.class);


### PR DESCRIPTION
Removed the method that prints "Checks if running on a Unix-like node".
We see a lot of noise in the output because of this statement as it is called every time the docker-workflow-plugin and the hashicorp-vault-plugin uses the isUnix() method.
I also see a ticket filed on Jenkins to remove this (https://issues.jenkins.io/browse/JENKINS-61195), So this will be beneficial for many other consumers.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
