### PR TITLE
document environment variables are case insensitive

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/EnvStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/EnvStep/help.html
@@ -1,6 +1,6 @@
 <div>
 Sets one or more environment variables within a block.
-The names of environment variables are case insensitive but case preserving, i.e., setting `Foo` will change the value of `FOO` if it already exists.
+The names of environment variables are case-insensitive but case-preserving, that is, setting `Foo` will change the value of `FOO` if it already exists.
 Environment variables are available to any external processes spawned within that scope.
 For example:
 <p><pre>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/EnvStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/EnvStep/help.html
@@ -1,6 +1,7 @@
 <div>
 Sets one or more environment variables within a block.
-These are available to any external processes spawned within that scope.
+The names of environment variables are case insensitive but case preserving.
+Environment variables are available to any external processes spawned within that scope.
 For example:
 <p><pre>
 node {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/EnvStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/EnvStep/help.html
@@ -1,6 +1,6 @@
 <div>
 Sets one or more environment variables within a block.
-The names of environment variables are case insensitive but case preserving.
+The names of environment variables are case insensitive but case preserving, i.e., setting `Foo` will change the value of `FOO` if it already exists.
 Environment variables are available to any external processes spawned within that scope.
 For example:
 <p><pre>


### PR DESCRIPTION
Document that environment variables are case insensitive but case preserving as per https://javadoc.jenkins.io/hudson/EnvVars.html#:~:text=So%20for%20a%20consistent%20cross%20platform%20behavior%2C%20it%20creates%20the%20least%20confusion%20to%20make%20the%20table%20case%20insensitive%20but%20case%20preserving.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
