### PR TITLE
Fix flaky CatchErrorStepTest 

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
@@ -166,10 +166,10 @@ public class CatchErrorStepTest {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
                 "import jenkins.model.CauseOfInterruption\n" +
-                        "import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException\n" +
-                        "catchError(message: 'caught error') {\n" +
-                        "  throw new FlowInterruptedException(Result.ABORTED, true, new CauseOfInterruption[0])\n" +
-                        "}", false));
+                "import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException\n" +
+                "catchError(message: 'caught error') {\n" +
+                "  throw new FlowInterruptedException(Result.ABORTED, true, new CauseOfInterruption[0])\n" +
+                "}", false));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertCatchError(r, b, Result.ABORTED, Result.ABORTED, true);
     }
@@ -178,10 +178,10 @@ public class CatchErrorStepTest {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
                 "import jenkins.model.CauseOfInterruption\n" +
-                        "import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException\n" +
-                        "catchError(message: 'caught error', catchInterruptions: false) {\n" +
-                        "  throw new FlowInterruptedException(Result.ABORTED, true, new CauseOfInterruption[0])\n" +
-                        "}", false));
+                "import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException\n" +
+                "catchError(message: 'caught error', catchInterruptions: false) {\n" +
+                "  throw new FlowInterruptedException(Result.ABORTED, true, new CauseOfInterruption[0])\n" +
+                "}", false));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertCatchError(r, b, Result.ABORTED, null, false);
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
@@ -162,26 +162,26 @@ public class CatchErrorStepTest {
         assertCatchError(r, b, Result.SUCCESS, Result.UNSTABLE, true);
     }
 
-    @Test public void catchesTimeoutsByDefault() throws Exception {
+    @Test public void catchesInterruptionsByDefault() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "timeout(time: 1, unit: 'SECONDS') {\n" +
-                "  catchError(message: 'caught error') {\n" +
-                "    sleep 5\n" +
-                "  }\n" +
-                "}", true));
+                "import jenkins.model.CauseOfInterruption\n" +
+                        "import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException\n" +
+                        "catchError(message: 'caught error') {\n" +
+                        "  throw new FlowInterruptedException(Result.ABORTED, true, new CauseOfInterruption[0])\n" +
+                        "}", false));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertCatchError(r, b, Result.ABORTED, Result.ABORTED, true);
     }
 
-    @Test public void canAvoidCatchingTimeoutsWithOption() throws Exception {
+    @Test public void canAvoidCatchingInterruptionsWithOption() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                "timeout(time: 1, unit: 'SECONDS') {\n" +
-                "  catchError(message: 'caught error', catchInterruptions: false) {\n" +
-                "    sleep 5\n" +
-                "  }\n" +
-                "}", true));
+                "import jenkins.model.CauseOfInterruption\n" +
+                        "import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException\n" +
+                        "catchError(message: 'caught error', catchInterruptions: false) {\n" +
+                        "  throw new FlowInterruptedException(Result.ABORTED, true, new CauseOfInterruption[0])\n" +
+                        "}", false));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertCatchError(r, b, Result.ABORTED, null, false);
     }


### PR DESCRIPTION
Cloudbees CI reported a that [CatchErrorStepTest#catchesInterruptionsByDefault](https://github.com/Pldi23/workflow-basic-steps-plugin/blob/e6731c5a9e39737be611cb0bb6a7f321e98ad967/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java#L165) is flaky.

Logs:
[stderr_BEE-18075.txt](https://github.com/jenkinsci/workflow-basic-steps-plugin/files/9267134/stderr_BEE-18075.txt)
[stacktrace_BEE-18075.txt](https://github.com/jenkinsci/workflow-basic-steps-plugin/files/9267135/stacktrace_BEE-18075.txt)


Solution:
Avoid any sensitivity to timing by removing timeout step and throwing directly.
