### PR TITLE
`ReadWriteFileStepTest.testBinaryFileRoundtrip` flake on Windows

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/ReadWriteFileStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/ReadWriteFileStepTest.java
@@ -148,6 +148,7 @@ public class ReadWriteFileStepTest {
         assertThat("The data should round-trip correctly using Base64 encoding",
                 getBytes(p, "round-trip-base64"), equalTo(bytes));
         SemaphoreStep.success("bytes-checked/1", null);
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
     }
 
     private byte[] getBytes(TopLevelItem item, String fileName) throws Exception {


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/261/checks?check_run_id=11462904310 from #261

```
Unable to remove directory C:\Jenkins\workspace\rkflow-basic-steps-plugin_PR-261\target\tmp\j h11085138558253891864\jobs\p\builds\1 with directory contents: [C:\Jenkins\workspace\rkflow-basic-steps-plugin_PR-261\target\tmp\j h11085138558253891864\jobs\p\builds\1\atomic8521378833125757585tmp]
```
