### PR TITLE
Noting `artifact-manager-s3` impact on `stash`

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/stash/StashStep/help.html
@@ -15,4 +15,7 @@
     This is because stashed files are archived in a compressed TAR, and with large files this demands considerable
     resources on the controller, particularly CPU time.
     There's not a hard stash size limit, but between 5-100 MB you should probably consider alternatives.
+    If you use the Artifact Manager on S3 plugin, or another plugin with a remote atifact manager,
+    you can use this step without affecting controller performance
+    since stashes will be sent directly to S3 from the agent (and similarly for <code>unstash</code>).
 </div>


### PR DESCRIPTION
#291 reminded me of an important point that had been forgotten here.