### PR TITLE
JENKINS-61474 Improve null safety of the tool step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ToolStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ToolStep.java
@@ -152,7 +152,7 @@ public final class ToolStep extends Step {
                     continue;
                 }
                 for (ToolInstallation tool : desc.getInstallations()) {
-                    if (tool.getName().equals(name)) {
+                    if (name.equals(tool.getName())) {
                         if (tool instanceof NodeSpecific) {
                             tool = (ToolInstallation) ((NodeSpecific<?>) tool).forNode(getContext().get(Node.class), getContext().get(TaskListener.class));
                         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/ToolStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/ToolStepTest.java
@@ -48,6 +48,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.ToolInstallations;
@@ -116,6 +117,21 @@ public class ToolStepTest {
         p.setDefinition(new CpsFlowDefinition("node {def home = tool name: '" + tool.getName() + "', type: '" + MockToolWithoutSymbol.class.getName() + "'\n"
                 + "echo \"${home}\"}",
                 true));
+        r.assertLogContains(toolHome.getAbsolutePath(),
+                r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+    }
+
+    @Issue("JENKINS-61474") @Test public void toolWithoutName() throws Exception {
+        File toolHome = folder.newFolder("mockTools");
+        MockToolWithSymbol misconfiguredTool = new MockToolWithSymbol(null, toolHome.getAbsolutePath(), JenkinsRule.NO_PROPERTIES);
+        MockToolWithSymbol tool = new MockToolWithSymbol("mock-tool-with-symbol", toolHome.getAbsolutePath(), JenkinsRule.NO_PROPERTIES);
+        r.jenkins.getDescriptorByType(MockToolWithSymbol.MockToolWithSymbolDescriptor.class).setInstallations(misconfiguredTool, tool);
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {def home = tool \"" + tool.getName() + "\"\n"
+                +"echo \"${home}\"}",
+                true));
+
         r.assertLogContains(toolHome.getAbsolutePath(),
                 r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }


### PR DESCRIPTION
Tools page doesn't prevent submission of empty tool names. Some tools (e.g. Allure Commandline) use `Util.fixEmptyAndTrim` on the name, so there is a possibility of NPE when comparing the tool names. By flipping the comparison we avoid NPE since `tool` step requires `name` argument.

This most likely fixes https://issues.jenkins.io/browse/JENKINS-61474

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
