### PR TITLE
Log a note when `catchError` sets build result

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
@@ -248,6 +248,7 @@ public final class CatchErrorStep extends Step implements CatchExecutionOptions 
                         Functions.printStackTrace(t, listener.getLogger());
                     }
                     if (buildResult.isWorseThan(Result.SUCCESS)) {
+                        listener.getLogger().println("Setting overall build result to " + buildResult);
                         context.get(Run.class).setResult(buildResult);
                     }
                     if (stepResult.isWorseThan(Result.SUCCESS)) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStep.java
@@ -248,8 +248,12 @@ public final class CatchErrorStep extends Step implements CatchExecutionOptions 
                         Functions.printStackTrace(t, listener.getLogger());
                     }
                     if (buildResult.isWorseThan(Result.SUCCESS)) {
-                        listener.getLogger().println("Setting overall build result to " + buildResult);
-                        context.get(Run.class).setResult(buildResult);
+                        Run<?, ?> build = context.get(Run.class);
+                        Result currentResult = build.getResult();
+                        if (currentResult == null || buildResult.isWorseThan(currentResult)) {
+                            listener.getLogger().println("Setting overall build result to " + buildResult);
+                        } // otherwise WorkflowRun.setResult should be a no-op, so do not log anything
+                        build.setResult(buildResult);
                     }
                     if (stepResult.isWorseThan(Result.SUCCESS)) {
                         context.get(FlowNode.class).addOrReplaceAction(new WarningAction(stepResult).withMessage(message));

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/CatchErrorStepTest.java
@@ -118,6 +118,7 @@ public class CatchErrorStepTest {
                 "}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertCatchError(r, b, Result.UNSTABLE, null, true);
+        r.assertLogContains("Setting overall build result to UNSTABLE", b);
     }
 
     @Test public void invalidBuildResult() throws Exception {


### PR DESCRIPTION
Otherwise it can be confusing why a build had the result that it did. Observed in a pipeline using the idiom

```groovy
retry(count: 2, conditions: [kubernetesAgent(), nonresumable()]) {
  node(POD_LABEL) {
    stage('build') {
      withMockLoad(averageDuration: 180) {
        catchError(buildResult: 'UNSTABLE') {
          sh MOCK_LOAD_COMMAND
        }
      }
    }
    stage('publish') {
      junit 'mock-junit.xml'
      archiveArtifacts artifacts: 'mock-artifact-*.txt', allowEmptyArchive: true, fingerprint: true
    }
  }
}
```

When the first pod is killed, the `node` block retried and the build ran to completion (`FlowEndNode` set to `SUCCESS`) yet the `Run` is set to `UNSTABLE`, which is what the step is supposed to do but unintentional here; the reason for the `catchError` was rather to work around an exit code of 1 from the mock load command due to mock test failures, which is better handled via https://github.com/jenkinsci/mock-load-builder-plugin/pull/102.
