### PR TITLE
Revert cleanup from #321

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <scope>test</scope>
+            <scope>runtime</scope> <!-- TODO switch to test once 1227.vdc0a_d1fd4338 or later is widely adopted -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Reverting a small bit of cleanup from #321 as it is unrelated to the core Jakarta EE 9 effort and seems to be causing various cryptic PCT failures as seen in https://github.com/jenkinsci/bom/pull/4302.