### PR TITLE
[JENKINS-29037] waitUntil: Make maximum recurrence period configurable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep.java
@@ -40,9 +40,10 @@ import org.kohsuke.stapler.DataBoundSetter;
 public final class WaitForConditionStep extends Step {
 
     static final long MIN_RECURRENCE_PERIOD = 250; // ¼s
-    static final long MAX_RECURRENCE_PERIOD = 15000; // ¼min
+    static final long DEFAULT_MAX_RECURRENCE_PERIOD = 15000; // ¼min
 
     private long initialRecurrencePeriod = MIN_RECURRENCE_PERIOD;
+    private long maxRecurrencePeriod = DEFAULT_MAX_RECURRENCE_PERIOD;
     private boolean quiet = false;
 
     @DataBoundConstructor
@@ -50,12 +51,20 @@ public final class WaitForConditionStep extends Step {
 
     @DataBoundSetter
     public void setInitialRecurrencePeriod(long initialRecurrencePeriod) {
-        this.initialRecurrencePeriod =
-                Math.max(MIN_RECURRENCE_PERIOD, Math.min(initialRecurrencePeriod, MAX_RECURRENCE_PERIOD));
+        this.initialRecurrencePeriod = Math.max(MIN_RECURRENCE_PERIOD, initialRecurrencePeriod);
     }
 
     public long getInitialRecurrencePeriod() {
         return initialRecurrencePeriod;
+    }
+
+    @DataBoundSetter
+    public void setMaxRecurrencePeriod(long maxRecurrencePeriod) {
+        this.maxRecurrencePeriod = maxRecurrencePeriod;
+    }
+
+    public long getMaxRecurrencePeriod(long maxRecurrencePeriod) {
+        return maxRecurrencePeriod;
     }
 
     @DataBoundSetter
@@ -69,7 +78,11 @@ public final class WaitForConditionStep extends Step {
 
     @Override
     public StepExecution start(StepContext context) throws Exception {
-        return new Execution(context, initialRecurrencePeriod, this.quiet);
+        if (maxRecurrencePeriod < initialRecurrencePeriod) {
+            throw new IllegalStateException("The initial recurrance period must not be greater than the maximum.");
+        }
+        long initial = Math.max(MIN_RECURRENCE_PERIOD, Math.min(initialRecurrencePeriod, maxRecurrencePeriod));
+        return new Execution(context, initial, maxRecurrencePeriod, this.quiet);
     }
 
     public static final class Execution extends AbstractStepExecutionImpl {
@@ -85,12 +98,14 @@ public final class WaitForConditionStep extends Step {
 
         private static final float RECURRENCE_PERIOD_BACKOFF = 1.2f;
         private long initialRecurrencePeriod;
+        private long maxRecurrencePeriod;
         long recurrencePeriod;
         private final boolean quiet;
 
-        Execution(StepContext context, long initialRecurrencePeriod, boolean quiet) {
+        Execution(StepContext context, long initialRecurrencePeriod, long maxRecurrencePeriod, boolean quiet) {
             super(context);
             this.initialRecurrencePeriod = initialRecurrencePeriod;
+            this.maxRecurrencePeriod = maxRecurrencePeriod;
             recurrencePeriod = initialRecurrencePeriod;
             this.quiet = quiet;
         }
@@ -99,6 +114,9 @@ public final class WaitForConditionStep extends Step {
             // in case we are deserializing an older version of this object prior to this field being added
             if (initialRecurrencePeriod == 0) {
                 initialRecurrencePeriod = MIN_RECURRENCE_PERIOD;
+            }
+            if (maxRecurrencePeriod == 0) {
+                maxRecurrencePeriod = DEFAULT_MAX_RECURRENCE_PERIOD;
             }
             return this;
         }
@@ -162,7 +180,7 @@ public final class WaitForConditionStep extends Step {
                             },
                             recurrencePeriod,
                             TimeUnit.MILLISECONDS);
-            recurrencePeriod = Math.min((long) (recurrencePeriod * RECURRENCE_PERIOD_BACKOFF), MAX_RECURRENCE_PERIOD);
+            recurrencePeriod = Math.min((long) (recurrencePeriod * RECURRENCE_PERIOD_BACKOFF), maxRecurrencePeriod);
         }
 
         @Override

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/WaitForConditionStep/config.jelly
@@ -28,6 +28,9 @@ THE SOFTWARE.
     <f:entry field="initialRecurrencePeriod" title="${%Initial Recurrence Period Milliseconds}">
         <f:number clazz="positive-number"/>
     </f:entry>
+    <f:entry field="maxRecurrencePeriod" title="${%Maximum Recurrence Period Milliseconds}">
+        <f:number clazz="positive-number"/>
+    </f:entry>
     <f:entry field="quiet" title="${%Quiet Mode}">
         <f:checkbox checked="false"/>
     </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/WaitForConditionStepTest.java
@@ -93,6 +93,27 @@ class WaitForConditionStepTest {
     }
 
     @Test
+    void maxRecurrence() throws Throwable {
+        sessions.then(j -> {
+            WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition(
+                    "waitUntil(initialRecurrencePeriod: 250, maxRecurrencePeriod: 255) {semaphore 'wait'}; semaphore 'waited'", true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            SemaphoreStep.waitForStart("wait/1", b);
+            SemaphoreStep.success("wait/1", false);
+            SemaphoreStep.waitForStart("wait/2", b);
+            SemaphoreStep.success("wait/2", false);
+            SemaphoreStep.waitForStart("wait/3", b);
+            SemaphoreStep.success("wait/3", true);
+            SemaphoreStep.waitForStart("waited/1", b);
+            SemaphoreStep.success("waited/1", null);
+            WorkflowRun run = j.assertBuildStatusSuccess(j.waitForCompletion(b));
+            j.assertLogContains("Will try again after " + Util.getTimeSpanString(250), run);
+            j.assertLogContains("Will try again after " + Util.getTimeSpanString(255), run);
+        });
+    }
+
+    @Test
     void failure() throws Throwable {
         sessions.then(j -> {
             WorkflowJob p = j.createProject(WorkflowJob.class, "p");


### PR DESCRIPTION
As suggested also in https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/7#issuecomment-663683392 ff, this adds a `maxRecurrencePeriod` parameter.

Fixes https://github.com/jenkinsci/workflow-basic-steps-plugin/issues/395

### Testing done

Extended the existing `WaitForConditionStepTest` class by a new case `maxRecurrence()` that sets deliberately a very low max limit in order to test that this limit is hit and maintained.
I'm not sure if there is a convenient method to verify that that there are no other wait periods printed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed